### PR TITLE
Add logo to app header

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="black">
+  <path d="M112 64h128l-48 384H64z"/>
+  <path d="M304 256l96 192h-96l-96-192z"/>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Image from 'next/image';
 import { supabase } from '@/lib/supabaseClient';
 
 type Project = { id: string; imageUrl: string; prompt: string; user: string };
@@ -91,8 +92,11 @@ export default function Home() {
 
   return (
     <main className="min-h-screen p-6">
-      <header className="mb-6 flex justify-between">
-        <h1 className="text-2xl font-bold">kuchnie.ai</h1>
+      <header className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Image src="/logo.svg" alt="kuchnie.ai logo" width={32} height={32} />
+          <h1 className="text-2xl font-bold">kuchnie.ai</h1>
+        </div>
 
         <div className="flex items-center gap-2">
           {user ? (


### PR DESCRIPTION
## Summary
- show logo next to "kuchnie.ai" in header
- add logo asset

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c4586d27f48329be3246443fe3b0c5