### PR TITLE
feat: add user menu and gallery page

### DIFF
--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { supabase } from '@/lib/supabaseClient';
+
+type Project = { id: string; imageUrl: string; prompt: string; user: string };
+
+export default function Gallery() {
+  const [user, setUser] = useState<any>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => setUser(data.user ?? null));
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!user) {
+      setProjects([]);
+      return;
+    }
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('projects')
+        .select('id, image_url, prompt, user')
+        .eq('user', user.email)
+        .order('created_at', { ascending: false });
+
+      if (error) {
+        console.error('[DB fetch error]', error);
+        return;
+      }
+
+      setProjects(
+        (data || []).map((row: any) => ({
+          id: row.id,
+          imageUrl: row.image_url,
+          prompt: row.prompt,
+          user: row.user,
+        })),
+      );
+    };
+    load();
+  }, [user]);
+
+  if (!user) {
+    return <main className="p-6">Musisz się zalogować, aby zobaczyć galerię.</main>;
+  }
+
+  return (
+    <main className="min-h-screen p-6">
+      <header className="mb-6 flex items-center gap-2">
+        <Link href="/" className="text-lg">
+          &larr; Wróć
+        </Link>
+        <h2 className="text-2xl font-bold">Moja galeria</h2>
+      </header>
+
+      <section className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        {projects.length === 0 && (
+          <p className="col-span-full text-gray-500">Brak projektów</p>
+        )}
+        {projects.map((p) => (
+          <figure key={p.id} className="border rounded overflow-hidden">
+            <img
+              src={p.imageUrl}
+              alt={p.prompt}
+              className="w-full h-48 object-cover"
+            />
+            <figcaption className="p-2 text-sm">
+              <strong>{p.prompt}</strong>
+            </figcaption>
+          </figure>
+        ))}
+      </section>
+    </main>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { supabase } from '@/lib/supabaseClient';
 
 type Project = { id: string; imageUrl: string; prompt: string; user: string };
@@ -12,6 +13,7 @@ export default function Home() {
   const [loading, setLoading] = useState(false);
   const [user, setUser] = useState<any>(null);
   const [selectedImage, setSelectedImage] = useState<Project | null>(null);
+  const [showMenu, setShowMenu] = useState(false);
 
   // 1) Pobierz usera przy starcie + słuchaj zmian sesji (login/logout)
   useEffect(() => {
@@ -43,6 +45,20 @@ export default function Home() {
       }
     }
   }, [user]);
+
+  const handleChangeNick = async () => {
+    const nick = window.prompt(
+      'Podaj nowy nick:',
+      user?.user_metadata?.nick || '',
+    )?.trim();
+    if (!nick) return;
+    const { data, error } = await supabase.auth.updateUser({ data: { nick } });
+    if (error) {
+      alert('Nie udało się zapisać nicku');
+      return;
+    }
+    setUser(data.user);
+  };
 
   // 3) Wczytaj projekty zalogowanego usera
   useEffect(() => {
@@ -161,10 +177,35 @@ export default function Home() {
           <h1 className="text-2xl font-bold">kuchnie.ai</h1>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 relative">
           {user ? (
             <>
-              <span className="mr-2">{user.user_metadata?.nick || user.email}</span>
+              <button
+                onClick={() => setShowMenu((s) => !s)}
+                className="mr-2"
+              >
+                {user.user_metadata?.nick || user.email}
+              </button>
+              {showMenu && (
+                <div className="absolute right-0 mt-2 w-48 bg-white border rounded shadow">
+                  <button
+                    onClick={() => {
+                      setShowMenu(false);
+                      handleChangeNick();
+                    }}
+                    className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                  >
+                    Zmień nick
+                  </button>
+                  <Link
+                    href="/gallery"
+                    className="block px-4 py-2 hover:bg-gray-100"
+                    onClick={() => setShowMenu(false)}
+                  >
+                    Moja galeria
+                  </Link>
+                </div>
+              )}
               <button onClick={signOut} className="border rounded px-3 py-1">Wyloguj</button>
             </>
           ) : (


### PR DESCRIPTION
## Summary
- add dropdown user menu with nickname edit and link to gallery
- create gallery page to browse user projects

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*
- `npm run build` *(fails: Turbopack build failed with 2 errors: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c48894be4c8329b3501039098d04ce