### PR TITLE
Remove logo image from main page header

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Image from 'next/image';
 import Link from 'next/link';
 import { supabase } from '@/lib/supabaseClient';
 
@@ -173,7 +172,6 @@ export default function Home() {
     <main className="min-h-screen p-6">
       <header className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Image src="/logo.svg" alt="kuchnie.ai logo" width={32} height={32} />
           <h1 className="text-2xl font-bold">kuchnie.ai</h1>
         </div>
 


### PR DESCRIPTION
## Summary
- Remove `Image` logo from main page header so only the text "kuchnie.ai" remains

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*
- `npm run build` *(fails: Failed to fetch `Geist` fonts from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c48b7092c8832997f1eced9ccf8aa7