### PR TITLE
feat(auth): add login menu and registration fields

### DIFF
--- a/src/app/add-company/page.tsx
+++ b/src/app/add-company/page.tsx
@@ -1,0 +1,8 @@
+export default function AddCompanyPage() {
+  return (
+    <div className="p-6">
+      <h2 className="text-xl mb-2">Dodaj firmę</h2>
+      <p>Funkcja w budowie.</p>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [nick, setNick] = useState('');
+  const [postalCode, setPostalCode] = useState('');
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { nick, postal_code: postalCode } },
+    });
+    if (error) {
+      alert(error.message);
+    } else {
+      router.push('/');
+    }
+  };
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      alert(error.message);
+    } else {
+      router.push('/');
+    }
+  };
+
+  return (
+    <div className="p-6">
+      <h2 className="mb-4 text-xl">Logowanie / Rejestracja</h2>
+      <form className="flex flex-col gap-2 max-w-xs">
+        <input
+          className="border p-2"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          type="password"
+          placeholder="Hasło"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Nick"
+          value={nick}
+          onChange={(e) => setNick(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          placeholder="Kod pocztowy"
+          value={postalCode}
+          onChange={(e) => setPostalCode(e.target.value)}
+        />
+        <div className="mt-2 flex gap-2">
+          <button onClick={handleLogin} className="border rounded px-3 py-1">
+            Zaloguj
+          </button>
+          <button onClick={handleRegister} className="border rounded px-3 py-1">
+            Zarejestruj
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import AuthButtons from '@/components/AuthButtons';
 
 type Project = {
   id: string;            // id rekordu w DB
@@ -220,38 +221,11 @@ export default function Home() {
     setProjects(prev => prev.filter(p => p.id !== proj.id));
   };
 
-  // --- LOGOWANIE ---
-  const signInWithGoogle = async () => {
-    await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: { redirectTo: `${window.location.origin}/` },
-    });
-  };
-  const signInWithEmail = async () => {
-    const email = window.prompt('Podaj maila (Supabase magic link):') || '';
-    if (!email) return;
-    const { error } = await supabase.auth.signInWithOtp({ email });
-    alert(error ? 'Błąd logowania' : 'Sprawdź maila i kliknij link.');
-  };
-  const signOut = async () => { await supabase.auth.signOut(); setUser(null); };
-
   return (
     <main className="min-h-screen p-6">
       <header className="mb-6 flex justify-between">
         <h1 className="text-2xl font-bold">kuchnie.ai</h1>
-        <div className="flex items-center gap-2">
-          {user ? (
-            <>
-              <span className="mr-2">{user.email}</span>
-              <button onClick={signOut} className="border rounded px-3 py-1">Wyloguj</button>
-            </>
-          ) : (
-            <>
-              <button onClick={signInWithGoogle} className="border rounded px-3 py-1">Zaloguj przez Google</button>
-              <button onClick={signInWithEmail} className="border rounded px-3 py-1 opacity-70">mailem (fallback)</button>
-            </>
-          )}
-        </div>
+        <AuthButtons />
       </header>
 
       <section className="mb-4 flex gap-2">

--- a/src/components/AuthButtons.tsx
+++ b/src/components/AuthButtons.tsx
@@ -1,16 +1,16 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { supabase } from '@/lib/supabaseClient';
 
 export default function AuthButtons() {
   const [user, setUser] = useState<null | { email?: string }>(null);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    // pobierz użytkownika przy starcie
     supabase.auth.getUser().then(({ data }) => setUser(data.user ?? null));
 
-    // słuchaj zmian sesji (login/logout)
     const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
       setUser(session?.user ?? null);
     });
@@ -23,27 +23,48 @@ export default function AuthButtons() {
   const signInWithGoogle = async () => {
     await supabase.auth.signInWithOAuth({
       provider: 'google',
-      options: {
-        // po logowaniu wróć na stronę główną (możesz zmienić)
-        redirectTo: `${window.location.origin}/`,
-      },
+      options: { redirectTo: `${window.location.origin}/` },
     });
   };
 
   const signOut = async () => {
     await supabase.auth.signOut();
-    // odśwież UI po wylogowaniu (opcjonalnie)
     window.location.reload();
   };
 
   if (user) {
     return (
-      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      <div className="flex items-center gap-2">
         <span>Zalogowany: {user.email}</span>
-        <button onClick={signOut}>Wyloguj</button>
+        <button onClick={signOut} className="border rounded px-3 py-1">Wyloguj</button>
       </div>
     );
   }
 
-  return <button onClick={signInWithGoogle}>Zaloguj przez Google</button>;
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="border rounded px-3 py-1"
+      >
+        Zaloguj
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-1 flex flex-col rounded border bg-white text-black shadow">
+          <Link href="/login" className="px-4 py-2 hover:bg-gray-100">
+            mail
+          </Link>
+          <button
+            onClick={signInWithGoogle}
+            className="px-4 py-2 text-left hover:bg-gray-100"
+          >
+            konto google
+          </button>
+          <Link href="/add-company" className="px-4 py-2 hover:bg-gray-100">
+            dodaj firmę
+          </Link>
+        </div>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- replace separate auth buttons with dropdown login menu
- add registration page capturing nick and postal code
- include placeholder page for adding a company

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c557d118448329bcf125e9433d7e16