### PR TITLE
Prompt for nickname and postal code on login

### DIFF
--- a/src/components/AuthButtons.tsx
+++ b/src/components/AuthButtons.tsx
@@ -2,17 +2,29 @@
 
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
+import { ensureProfile, type Profile } from '@/lib/profile';
 
 export default function AuthButtons() {
-  const [user, setUser] = useState<null | { email?: string }>(null);
+  const [user, setUser] = useState<any>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
 
   useEffect(() => {
+    const handleUser = async (u: any) => {
+      setUser(u);
+      if (u) {
+        const p = await ensureProfile(u.id);
+        setProfile(p);
+      } else {
+        setProfile(null);
+      }
+    };
+
     // pobierz użytkownika przy starcie
-    supabase.auth.getUser().then(({ data }) => setUser(data.user ?? null));
+    supabase.auth.getUser().then(({ data }) => handleUser(data.user ?? null));
 
     // słuchaj zmian sesji (login/logout)
     const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
-      setUser(session?.user ?? null);
+      handleUser(session?.user ?? null);
     });
 
     return () => {
@@ -39,7 +51,7 @@ export default function AuthButtons() {
   if (user) {
     return (
       <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-        <span>Zalogowany: {user.email}</span>
+        <span>Zalogowany: {profile?.nick}</span>
         <button onClick={signOut}>Wyloguj</button>
       </div>
     );

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -1,0 +1,33 @@
+import { supabase } from '@/lib/supabaseClient';
+
+export type Profile = {
+  nick: string;
+  postal_code: string;
+};
+
+export async function ensureProfile(userId: string): Promise<Profile> {
+  const { data } = await supabase
+    .from('profiles')
+    .select('nick, postal_code')
+    .eq('id', userId)
+    .single();
+
+  let nick = (data?.nick as string) || '';
+  let postal_code = (data?.postal_code as string) || '';
+
+  if (!nick) {
+    nick = window.prompt('Podaj nick:') || '';
+  }
+
+  if (!postal_code) {
+    postal_code = window.prompt('Podaj kod pocztowy:') || '';
+  }
+
+  await supabase.from('profiles').upsert({
+    id: userId,
+    nick,
+    postal_code,
+  });
+
+  return { nick, postal_code };
+}


### PR DESCRIPTION
## Summary
- Prompt new users for a nickname and postal code and save them in Supabase profiles.
- Show the stored nickname after authentication instead of the email address.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c55b67c82c8329a89fc71309c23a26