### PR TITLE
Cache profile request to avoid repeated prompts

### DIFF
--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -5,29 +5,39 @@ export type Profile = {
   postal_code: string;
 };
 
+// Cache promises per user to avoid multiple prompts when ensureProfile
+// is invoked concurrently from different components.
+const profilePromises: Record<string, Promise<Profile>> = {};
+
 export async function ensureProfile(userId: string): Promise<Profile> {
-  const { data } = await supabase
-    .from('profiles')
-    .select('nick, postal_code')
-    .eq('id', userId)
-    .single();
+  if (!profilePromises[userId]) {
+    profilePromises[userId] = (async () => {
+      const { data } = await supabase
+        .from('profiles')
+        .select('nick, postal_code')
+        .eq('id', userId)
+        .single();
 
-  let nick = (data?.nick as string) || '';
-  let postal_code = (data?.postal_code as string) || '';
+      let nick = (data?.nick as string) || '';
+      let postal_code = (data?.postal_code as string) || '';
 
-  if (!nick) {
-    nick = window.prompt('Podaj nick:') || '';
+      if (!nick) {
+        nick = window.prompt('Podaj nick:') || '';
+      }
+
+      if (!postal_code) {
+        postal_code = window.prompt('Podaj kod pocztowy:') || '';
+      }
+
+      await supabase.from('profiles').upsert({
+        id: userId,
+        nick,
+        postal_code,
+      });
+
+      return { nick, postal_code };
+    })();
   }
 
-  if (!postal_code) {
-    postal_code = window.prompt('Podaj kod pocztowy:') || '';
-  }
-
-  await supabase.from('profiles').upsert({
-    id: userId,
-    nick,
-    postal_code,
-  });
-
-  return { nick, postal_code };
+  return profilePromises[userId];
 }


### PR DESCRIPTION
## Summary
- cache `ensureProfile` results so simultaneous calls share one prompt

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*
- `npm run build` *(fails: Failed to fetch Geist font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c55d4bd3b08329a3c2ec54f5b549e2