### PR TITLE
Use single dialog for profile input

### DIFF
--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -21,12 +21,10 @@ export async function ensureProfile(userId: string): Promise<Profile> {
       let nick = (data?.nick as string) || '';
       let postal_code = (data?.postal_code as string) || '';
 
-      if (!nick) {
-        nick = window.prompt('Podaj nick:') || '';
-      }
-
-      if (!postal_code) {
-        postal_code = window.prompt('Podaj kod pocztowy:') || '';
+      if (!nick || !postal_code) {
+        const profile = await promptProfile({ nick, postal_code });
+        nick = profile.nick;
+        postal_code = profile.postal_code;
       }
 
       await supabase.from('profiles').upsert({
@@ -40,4 +38,40 @@ export async function ensureProfile(userId: string): Promise<Profile> {
   }
 
   return profilePromises[userId];
+}
+
+function promptProfile(defaults: Profile): Promise<Profile> {
+  return new Promise((resolve) => {
+    const dialog = document.createElement('dialog');
+
+    dialog.innerHTML = `
+      <form method="dialog" style="display:flex; flex-direction:column; gap:8px;">
+        <label>
+          Nick:
+          <input name="nick" value="${defaults.nick}" />
+        </label>
+        <label>
+          Kod pocztowy:
+          <input name="postal_code" value="${defaults.postal_code}" />
+        </label>
+        <menu style="display:flex; gap:8px; justify-content:flex-end;">
+          <button value="cancel">Anuluj</button>
+          <button value="default">OK</button>
+        </menu>
+      </form>
+    `;
+
+    document.body.appendChild(dialog);
+
+    dialog.addEventListener('close', () => {
+      const form = dialog.querySelector('form')!;
+      const nickInput = form.querySelector('input[name="nick"]') as HTMLInputElement;
+      const postalInput = form.querySelector('input[name="postal_code"]') as HTMLInputElement;
+      const profile = { nick: nickInput.value, postal_code: postalInput.value };
+      dialog.remove();
+      resolve(profile);
+    });
+
+    dialog.showModal();
+  });
 }


### PR DESCRIPTION
## Summary
- Replace multiple prompt pop-ups with one dialog collecting nick and postal code
- Add dialog helper to gather profile information in a single step

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c55ec8aa0883299d136d5d1f27b666