### PR TITLE
feat: allow editing profile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
-import { ensureProfile, type Profile } from '@/lib/profile';
+import { ensureProfile, editProfile, type Profile } from '@/lib/profile';
 
 type Project = {
   id: string;            // id rekordu w DB
@@ -254,7 +254,15 @@ export default function Home() {
         <div className="flex items-center gap-2">
           {user ? (
             <>
-              <span className="mr-2">{profile?.nick}</span>
+              <button
+                onClick={async () => {
+                  const p = await editProfile(user.id, profile);
+                  setProfile(p);
+                }}
+                className="mr-2 underline"
+              >
+                {profile?.nick}
+              </button>
               <button onClick={signOut} className="border rounded px-3 py-1">Wyloguj</button>
             </>
           ) : (

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -62,6 +62,24 @@ export async function ensureProfile(userId: string): Promise<Profile> {
   return profilePromises[userId];
 }
 
+export async function editProfile(userId: string, current: Profile | null): Promise<Profile> {
+  const defaults = current ?? { nick: '', postal_code: '' };
+  const profile = await promptProfile(defaults);
+
+  await supabase.from('profiles').upsert({
+    id: userId,
+    ...profile,
+  });
+
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(`profile_${userId}`, JSON.stringify(profile));
+  }
+
+  profilePromises[userId] = Promise.resolve(profile);
+
+  return profile;
+}
+
 function promptProfile(defaults: Profile): Promise<Profile> {
   return new Promise((resolve) => {
     const dialog = document.createElement('dialog');


### PR DESCRIPTION
## Summary
- allow editing profile through a dialog when clicking the user's nickname
- update profile storage after editing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c56286204c8329b182771725e2f8e3