### PR TITLE
Remove photo credit from thumbnails

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -347,7 +347,6 @@ export default function Home() {
             />
             <figcaption className="p-2 text-sm pr-16">
               <strong className="block">{p.prompt}</strong>
-              <p className="text-xs opacity-70">by {p.user}</p>
             </figcaption>
             <button
               onClick={() => handleDelete(p)}


### PR DESCRIPTION
## Summary
- remove user credit line from image thumbnails

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Failed to patch ESLint)


------
https://chatgpt.com/codex/tasks/task_b_68c56be9aa948329a46a7b2db4d582f6