### PR TITLE
Add logo before site title

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <polygon points="0,0 70,0 100,30 100,100 0,100" fill="#000"/>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
+import Image from 'next/image';
 import { supabase } from '@/lib/supabaseClient';
 import { ensureProfile, editProfile, type Profile } from '@/lib/profile';
 
@@ -289,8 +290,11 @@ export default function Home() {
 
   return (
     <main className="min-h-screen p-6">
-      <header className="mb-6 flex justify-between">
-        <h1 className="text-2xl font-bold">kuchnie.ai</h1>
+      <header className="mb-6 flex justify-between items-center">
+        <div className="flex items-center gap-2">
+          <Image src="/logo.svg" alt="kuchnie.ai logo" width={32} height={32} />
+          <h1 className="text-2xl font-bold">kuchnie.ai</h1>
+        </div>
         <div className="flex items-center gap-2">
           {user ? (
             <>


### PR DESCRIPTION
## Summary
- add logo image asset
- show logo next to site name in header

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*
- `npm run build` *(fails: Failed to fetch `Geist` and `Geist Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c56e069570832983bd725e762f8b6b