### PR TITLE
Replace logo with 32x32 version

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <polygon points="0,0 70,0 100,30 100,100 0,100" fill="#000"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <polygon points="0,0 22.4,0 32,9.6 32,32 0,32" fill="#000"/>
 </svg>


### PR DESCRIPTION
## Summary
- Replace previous oversized logo with compact 32x32 SVG version.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint module)*
- `npm run build` *(fails: Could not fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c5718b7488832984d926556c753836