### PR TITLE
Remove kuchnie.ai logo image

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <polygon points="0,0 22.4,0 32,9.6 32,32 0,32" fill="#000"/>
-</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
-import Image from 'next/image';
 import { supabase } from '@/lib/supabaseClient';
 import { ensureProfile, editProfile, type Profile } from '@/lib/profile';
 
@@ -320,8 +319,7 @@ export default function Home() {
   return (
     <main className="min-h-screen p-6">
       <header className="mb-6 flex justify-between items-center">
-        <div className="flex items-center gap-2">
-          <Image src="/logo.svg" alt="kuchnie.ai logo" width={24} height={24} />
+        <div className="flex items-center">
           <h1 className="text-2xl font-bold">kuchnie.ai</h1>
         </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- remove logo image beside the `kuchnie.ai` header
- delete unused `public/logo.svg`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*
- `npm run build` *(fails: Failed to fetch fonts from Google; build aborted)*

------
https://chatgpt.com/codex/tasks/task_b_68c57336fa8883299e32dbc1dff8f6a4