### PR TITLE
Add logo before site title

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="10" fill="#4b5563" />
+  <text x="12" y="16" font-size="12" text-anchor="middle" fill="white" font-family="Arial" font-weight="bold">K</text>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
+import Image from 'next/image';
 import { supabase } from '@/lib/supabaseClient';
 import { ensureProfile, editProfile, type Profile } from '@/lib/profile';
 
@@ -319,7 +320,8 @@ export default function Home() {
   return (
     <main className="min-h-screen p-6">
       <header className="mb-6 flex justify-between items-center">
-        <div className="flex items-center">
+        <div className="flex items-center gap-2">
+          <Image src="/logo.svg" alt="Logo" width={32} height={32} />
           <h1 className="text-2xl font-bold">kuchnie.ai</h1>
         </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add simple `logo.svg` asset
- display logo before `kuchnie.ai` title

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c5747c51048329ace2f54324c408cd