### PR TITLE
Add aspect ratio selection for image generation

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -11,7 +11,7 @@ function extractTextFromCandidates(resp: any): string {
 
 export async function POST(req: NextRequest) {
   try {
-    const { prompt } = await req.json();
+    const { prompt, aspectRatio } = await req.json();
     if (!prompt || typeof prompt !== 'string') {
       return NextResponse.json({ error: 'Brak promptu' }, { status: 400 });
     }
@@ -59,6 +59,11 @@ export async function POST(req: NextRequest) {
       process.env.IMAGEN_API_URL ||
       `https://generativelanguage.googleapis.com/v1beta/models/${imagenModel}:predict`;
 
+    const params: Record<string, any> = { sampleCount: 1 };
+    if (aspectRatio && typeof aspectRatio === 'string') {
+      params.aspectRatio = aspectRatio;
+    }
+
     const gen = await fetch(imagenUrl, {
       method: 'POST',
       headers: {
@@ -68,14 +73,7 @@ export async function POST(req: NextRequest) {
       body: JSON.stringify({
         // REST dla Imagen używa 'instances' + 'parameters'
         instances: [{ prompt: finalPrompt }],
-        parameters: {
-          // liczba obrazów (1–4), ratio/rozmiar możesz później podać z UI
-          sampleCount: 1,
-          // przykładowe parametry:
-          // aspectRatio: '16:9',
-          // sampleImageSize: '1K', // dla Standard/Ultra ('1K' lub '2K')
-          // personGeneration: 'allow_adult'
-        }
+        parameters: params,
       }),
     });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,10 +23,17 @@ export default function Home() {
   const [prompt, setPrompt] = useState('');
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(false);
+  const [aspectRatio, setAspectRatio] = useState('16:9');
+  const [menuOpen, setMenuOpen] = useState(false);
   const [user, setUser] = useState<any>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [fullscreenIndex, setFullscreenIndex] = useState<number | null>(null);
   const touchStartX = useRef<number | null>(null);
+
+  useEffect(() => {
+    const saved = typeof window !== 'undefined' ? localStorage.getItem('aspectRatio') : null;
+    if (saved) setAspectRatio(saved);
+  }, []);
 
   const showPrev = () => {
     setFullscreenIndex(i => (i === null ? i : (i - 1 + projects.length) % projects.length));
@@ -46,6 +53,14 @@ export default function Home() {
       diff > 0 ? showPrev() : showNext();
     }
     touchStartX.current = null;
+  };
+
+  const selectAspect = (ratio: string) => {
+    setAspectRatio(ratio);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('aspectRatio', ratio);
+    }
+    setMenuOpen(false);
   };
 
   // --- SESJA ---
@@ -150,7 +165,7 @@ export default function Home() {
       const res = await fetch('/api/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt }),
+        body: JSON.stringify({ prompt, aspectRatio }),
       });
 
       const data = await res.json().catch(() => ({} as any));
@@ -345,7 +360,7 @@ export default function Home() {
         </div>
       </header>
 
-      <section className="mb-4 flex gap-2">
+      <section className="mb-4 flex gap-2 items-start">
         <input
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
@@ -355,6 +370,37 @@ export default function Home() {
         <button onClick={handleGenerate} disabled={loading} className="border rounded px-3 py-2">
           {loading ? 'Generuję...' : 'Generuj'}
         </button>
+        <div className="relative">
+          <button
+            onClick={() => setMenuOpen((o) => !o)}
+            className="border rounded px-3 py-2"
+            aria-label="Opcje orientacji"
+          >
+            ☰
+          </button>
+          {menuOpen && (
+            <div className="absolute right-0 mt-2 w-32 bg-white border rounded shadow">
+              <button
+                onClick={() => selectAspect('9:16')}
+                className={`block w-full text-left px-3 py-2 hover:bg-gray-100 ${aspectRatio === '9:16' ? 'font-bold' : ''}`}
+              >
+                Pionowe
+              </button>
+              <button
+                onClick={() => selectAspect('1:1')}
+                className={`block w-full text-left px-3 py-2 hover:bg-gray-100 ${aspectRatio === '1:1' ? 'font-bold' : ''}`}
+              >
+                Kwadrat
+              </button>
+              <button
+                onClick={() => selectAspect('16:9')}
+                className={`block w-full text-left px-3 py-2 hover:bg-gray-100 ${aspectRatio === '16:9' ? 'font-bold' : ''}`}
+              >
+                Poziome
+              </button>
+            </div>
+          )}
+        </div>
       </section>
 
       <section className="grid grid-cols-2 md:grid-cols-3 gap-4">


### PR DESCRIPTION
## Summary
- add hamburger menu next to generate button to choose image orientation
- persist selected aspect ratio and send it to backend
- update generate API to accept aspect ratio parameter

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*
- `npm run build` *(fails: Failed to fetch `Geist` and `Geist Mono` fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c575c83bc08329ad6a7cf31c909ea1