### PR TITLE
Remove logo before site title

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
-import Image from 'next/image';
 import { supabase } from '@/lib/supabaseClient';
 import { ensureProfile, editProfile, type Profile } from '@/lib/profile';
 
@@ -321,7 +320,6 @@ export default function Home() {
     <main className="min-h-screen p-6">
       <header className="mb-6 flex justify-between items-center">
         <div className="flex items-center gap-2">
-          <Image src="/logo.svg" alt="Logo" width={32} height={32} />
           <h1 className="text-2xl font-bold">kuchnie.ai</h1>
         </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- remove logo icon preceding "kuchnie.ai" heading
- drop unused Image import

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c576de14b483298e48e6d9e9f06737