### PR TITLE
Adjust hamburger menu order and visibility

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -374,9 +374,6 @@ export default function Home() {
           placeholder="Opisz swoją kuchnię…"
           className="flex-1 border rounded px-3 py-2"
         />
-        <button onClick={handleGenerate} disabled={loading} className="border rounded px-3 py-2">
-          {loading ? 'Generuję...' : 'Generuj'}
-        </button>
         <div className="relative">
           <button
             onClick={() => setMenuOpen((o) => !o)}
@@ -386,7 +383,7 @@ export default function Home() {
             ☰
           </button>
           {menuOpen && (
-            <div className="absolute right-0 mt-2 w-32 bg-white border rounded shadow">
+            <div className="absolute right-0 mt-2 w-32 bg-white border rounded shadow z-50">
               <button
                 onClick={() => selectAspect('9:16')}
                 className={`block w-full text-left px-3 py-2 hover:bg-gray-100 ${aspectRatio === '9:16' ? 'font-bold' : ''}`}
@@ -408,6 +405,9 @@ export default function Home() {
             </div>
           )}
         </div>
+        <button onClick={handleGenerate} disabled={loading} className="border rounded px-3 py-2">
+          {loading ? 'Generuję...' : 'Generuj'}
+        </button>
       </section>
 
       <section className="grid grid-cols-2 md:grid-cols-3 gap-4">


### PR DESCRIPTION
## Summary
- Reorder control section so input field appears first, then the hamburger menu, and the "Generuj" button last
- Ensure the hamburger dropdown renders above images by applying a higher z-index

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Error: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c577b541288329854c435799238367