### PR TITLE
feat: disable scroll beneath fullscreen image

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,6 +40,15 @@ export default function Home() {
     if (saved) setAspectRatio(saved);
   }, []);
 
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.body.style.overflow = fullscreenIndex !== null ? 'hidden' : '';
+      return () => {
+        document.body.style.overflow = '';
+      };
+    }
+  }, [fullscreenIndex]);
+
   const showPrev = () => {
     setFullscreenIndex(i => (i === null ? i : (i - 1 + projects.length) % projects.length));
   };


### PR DESCRIPTION
## Summary
- prevent body from scrolling when a gallery image is opened fullscreen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c5795a5c7483298a73334eeef14f1c