### PR TITLE
Rename orientation labels in hamburger menu

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -395,7 +395,7 @@ export default function Home() {
                 onClick={() => selectAspect('9:16')}
                 className={`block w-full text-left px-3 py-2 hover:bg-gray-100 ${aspectRatio === '9:16' ? 'font-bold' : ''}`}
               >
-                Pionowe
+                Pion
               </button>
               <button
                 onClick={() => selectAspect('1:1')}
@@ -407,7 +407,7 @@ export default function Home() {
                 onClick={() => selectAspect('16:9')}
                 className={`block w-full text-left px-3 py-2 hover:bg-gray-100 ${aspectRatio === '16:9' ? 'font-bold' : ''}`}
               >
-                Poziome
+                Poziom
               </button>
             </div>
           )}


### PR DESCRIPTION
## Summary
- rename "Pionowe" to "Pion" in aspect ratio menu
- rename "Poziome" to "Poziom" in aspect ratio menu

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c57b3308888329b051cdf0e432cbd5