### PR TITLE
Remove prompts under gallery thumbnails

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -436,9 +436,6 @@ export default function Home() {
                 }
               }}
             />
-            <figcaption className="p-2 text-sm pr-16">
-              <strong className="block">{truncatePrompt(p.prompt, 5)}</strong>
-            </figcaption>
           </figure>
         ))}
       </section>


### PR DESCRIPTION
## Summary
- Hide prompt text under generated image thumbnails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68c5e1f35ea08329a27b557d26753676