### PR TITLE
Use mobile share for image download

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -304,26 +304,31 @@ export default function Home() {
   // --- ZAPIS DO GALERII ---
   const handleDownload = async (url: string) => {
     try {
-      const res = await fetch(url);
-      const blob = await res.blob();
-      const file = new File([blob], `kuchnia-${uuidish()}.png`, {
-        type: blob.type || 'image/png',
-      });
+      const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
-      if (navigator.canShare && navigator.canShare({ files: [file] })) {
-        await navigator.share({
-          files: [file],
-          title: 'kuchnie.ai',
-          text: 'Zapisz obraz w galerii',
+      if (isMobile && navigator.canShare) {
+        const res = await fetch(url);
+        const blob = await res.blob();
+        const file = new File([blob], `kuchnia-${uuidish()}.png`, {
+          type: blob.type || 'image/png',
         });
-      } else {
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = file.name;
-        document.body.appendChild(link);
-        link.click();
-        link.remove();
+
+        if (navigator.canShare({ files: [file] })) {
+          await navigator.share({
+            files: [file],
+            title: 'kuchnie.ai',
+            text: 'Zapisz obraz w galerii',
+          });
+          return;
+        }
       }
+
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `kuchnia-${uuidish()}.png`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
     } catch (e) {
       console.error('Błąd zapisu obrazka', e);
       alert('Nie udało się zapisać obrazka');


### PR DESCRIPTION
## Summary
- Use user agent detection to decide download strategy
- Share images to gallery on mobile and keep normal downloads on desktop

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Failed to patch ESLint because the calling module was not recognized)


------
https://chatgpt.com/codex/tasks/task_b_68c5e23c3024832997604fa10fbc4a31