### PR TITLE
Reduce gallery spacing and remove image borders

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -425,11 +425,11 @@ export default function Home() {
       {projects.length === 0 ? (
         <p className="text-gray-500">Na razie pusto – wygeneruj coś!</p>
       ) : (
-        <section className="columns-2 md:columns-3 gap-4">
+        <section className="columns-2 md:columns-3 gap-2">
           {projects.map((p, i) => (
             <figure
               key={p.id}
-              className="mb-4 break-inside-avoid relative border rounded overflow-hidden"
+              className="mb-2 break-inside-avoid relative"
             >
               <img
                 src={p.imageUrl}


### PR DESCRIPTION
## Summary
- tighten image gallery gaps for a denser layout
- remove borders and rounding for sharp-edged images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint)*

------
https://chatgpt.com/codex/tasks/task_b_68c5e68400008329be567a14b3652c37