### PR TITLE
Reduce spacing between thumbnails

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -425,11 +425,11 @@ export default function Home() {
       {projects.length === 0 ? (
         <p className="text-gray-500">Na razie pusto – wygeneruj coś!</p>
       ) : (
-        <section className="columns-2 md:columns-3 gap-2">
+        <section className="columns-2 md:columns-3 gap-1">
           {projects.map((p, i) => (
             <figure
               key={p.id}
-              className="mb-2 break-inside-avoid relative"
+              className="mb-1 break-inside-avoid relative"
             >
               <img
                 src={p.imageUrl}


### PR DESCRIPTION
## Summary
- Shrink gaps between gallery thumbnails for tighter layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c5e9a01b5883298f4544571f639135