### PR TITLE
Fix mobile gallery alignment on phones

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -425,12 +425,9 @@ export default function Home() {
       {projects.length === 0 ? (
         <p className="text-gray-500">Na razie pusto – wygeneruj coś!</p>
       ) : (
-        <section className="columns-2 md:columns-3 gap-1">
+        <section className="grid grid-cols-2 md:grid-cols-3 gap-1">
           {projects.map((p, i) => (
-            <figure
-              key={p.id}
-              className="mb-1 break-inside-avoid relative"
-            >
+            <figure key={p.id} className="relative">
               <img
                 src={p.imageUrl}
                 alt={p.prompt}


### PR DESCRIPTION
## Summary
- replace multicolumn layout with CSS grid to align gallery images from the top on phones

## Testing
- `npm run lint` (fails: Failed to patch ESLint because the calling module was not recognized)


------
https://chatgpt.com/codex/tasks/task_b_68c5eafc7f148329b4de17a3bc832063