### PR TITLE
Add responsive logo before site name

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+  <path d="M0 0h192l64 64v192H0z" fill="#000" />
+</svg>
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -354,6 +354,7 @@ export default function Home() {
     <main className="min-h-screen p-6">
       <header className="mb-6 flex justify-between items-center">
         <div className="flex items-center gap-2">
+          <img src="/logo.svg" alt="kuchnie.ai logo" className="w-8 h-8 md:w-10 md:h-10" />
           <h1 className="text-2xl font-bold">kuchnie.ai</h1>
         </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- display logo before site title in header
- add SVG logo file with responsive sizing for mobile and desktop

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint)*

------
https://chatgpt.com/codex/tasks/task_b_68c5f83f4158832982fbf6a32848c6a1