### PR TITLE
Use solid black background for fullscreen images

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -450,7 +450,7 @@ export default function Home() {
       )}
       {fullscreenIndex !== null && projects[fullscreenIndex] && (
         <div
-          className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center"
+          className="fixed inset-0 z-50 bg-black flex items-center justify-center"
           onClick={() => setFullscreenIndex(null)}
         >
           <button


### PR DESCRIPTION
## Summary
- ensure fullscreen overlay uses solid black background so thumbnails open on a completely black backdrop

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c669e06178832980c866590edc1a4a