### PR TITLE
Style fullscreen download and delete buttons

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -474,14 +474,14 @@ export default function Home() {
           <div className="absolute bottom-4 right-4 flex gap-2">
             <button
               onClick={(e) => { e.stopPropagation(); handleDownload(projects[fullscreenIndex].imageUrl); }}
-              className="text-black border border-black rounded px-3 py-1 text-sm bg-white"
+              className="text-white rounded px-3 py-1 text-sm bg-black/60"
               title="Zapisz obraz w galerii"
             >
               Pobierz
             </button>
             <button
               onClick={(e) => { e.stopPropagation(); handleDelete(projects[fullscreenIndex]); setFullscreenIndex(null); }}
-              className="text-red-600 border border-red-500 rounded px-3 py-1 text-sm bg-white"
+              className="text-white rounded px-3 py-1 text-sm bg-black/60"
               title="Usuń projekt"
             >
               Usuń


### PR DESCRIPTION
## Summary
- restyle "Pobierz" and "Usuń" fullscreen controls to use white text on the same dark overlay as the prompt display

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint)*
- `npm run build` *(fails: Failed to fetch Google Fonts `Geist` and `Geist Mono`)*

------
https://chatgpt.com/codex/tasks/task_b_68c66be6079083299dbca861334459f5