### PR TITLE
Add copy prompt button for fullscreen image

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -469,7 +469,16 @@ export default function Home() {
             onTouchEnd={(e) => { e.stopPropagation(); handleTouchEnd(e); }}
           />
           <div className="absolute bottom-4 left-4 right-40 text-white text-sm bg-black/60 p-2 rounded break-words">
-            {projects[fullscreenIndex].prompt}
+            <p>{projects[fullscreenIndex].prompt}</p>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                navigator.clipboard.writeText(projects[fullscreenIndex].prompt);
+              }}
+              className="mt-2 font-bold"
+            >
+              copy prompt
+            </button>
           </div>
           <div className="absolute bottom-4 right-4 flex gap-2">
             <button


### PR DESCRIPTION
## Summary
- add a bold "copy prompt" button to fullscreen image prompt overlay
- clicking the button copies the prompt to the clipboard

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Failed to patch ESLint because the calling module was not recognized)


------
https://chatgpt.com/codex/tasks/task_b_68c66cd1021c8329904199dbbc27d7a9