### PR TITLE
fix: keep fullscreen image above bottom nav

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -486,7 +486,7 @@ export default function Home() {
 
       {fullscreenIndex !== null && projects[fullscreenIndex] && (
         <div
-          className="fixed inset-0 z-50 bg-black overflow-hidden"
+          className="fixed inset-0 z-[60] bg-black overflow-hidden"
           onClick={() => setFullscreenIndex(null)}
         >
           <div


### PR DESCRIPTION
## Summary
- raise fullscreen overlay z-index to ensure images cover the bottom navigation

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*
- `npx eslint .` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c6e8646b4883298f73ff20eb27d138