### PR TITLE
Fade fullscreen arrows during drag

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -545,6 +545,7 @@ export default function Home() {
           </div>
           <button
             className="absolute left-4 top-1/2 -translate-y-1/2 text-white text-3xl p-2"
+            style={{ opacity: bgOpacity, transition: 'opacity 0.2s linear' }}
             onClick={(e) => { e.stopPropagation(); showPrev(); }}
             aria-label="Poprzednie zdjęcie"
           >
@@ -552,6 +553,7 @@ export default function Home() {
           </button>
           <button
             className="absolute right-4 top-1/2 -translate-y-1/2 text-white text-3xl p-2"
+            style={{ opacity: bgOpacity, transition: 'opacity 0.2s linear' }}
             onClick={(e) => { e.stopPropagation(); showNext(); }}
             aria-label="Następne zdjęcie"
           >


### PR DESCRIPTION
## Summary
- fade left/right navigation arrows as soon as a fullscreen image is dragged downward

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c6eed0c98c8329879fdb3c94ccfdd2