### PR TITLE
Adjust control fade-out speed for image drag

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,7 +48,7 @@ export default function Home() {
   const dragAxis = useRef<'x' | 'y' | null>(null);
   const screenW = typeof window !== 'undefined' ? window.innerWidth : 0;
   const screenH = typeof window !== 'undefined' ? window.innerHeight : 0;
-  const bgOpacity = 1 - Math.min(1, dragOffset.y / (screenH || 1));
+  const bgOpacity = 1 - Math.min(1, (dragOffset.y / (screenH || 1)) * 2);
 
   useEffect(() => {
     const saved = typeof window !== 'undefined' ? localStorage.getItem('aspectRatio') : null;


### PR DESCRIPTION
## Summary
- Speed up opacity fade-out for fullscreen image controls
- Controls now disappear once image is halfway dragged down

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Failed to patch ESLint because the calling module was not recognized)

------
https://chatgpt.com/codex/tasks/task_b_68c6efbf7ac883299e4db61a8ed3d205