### PR TITLE
Add bottom spacing for gallery

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -499,7 +499,7 @@ export default function Home() {
   };
 
   return (
-    <main className="min-h-screen p-6 pb-24">
+    <main className="min-h-screen p-6 pb-40">
       <header className="mb-6 flex items-center gap-2">
         <img src="/logo.svg" alt="kuchnie.ai logo" className="w-8 h-8 md:w-10 md:h-10" />
         <h1 className="text-2xl font-bold">kuchnie.ai</h1>


### PR DESCRIPTION
## Summary
- increase bottom padding on main gallery page so bottom menu no longer hides images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c6f57296188329af029f5a219c23a2