### PR TITLE
Auto-resizing prompt input shows generate button only when typing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,7 @@ function uuidish() {
 
 export default function Home() {
   const [prompt, setPrompt] = useState('');
+  const promptRef = useRef<HTMLTextAreaElement>(null);
   const [options, setOptions] = useState<string[]>([]);
   const featureOptions = [
     'Lodówka z prawej',
@@ -80,6 +81,14 @@ export default function Home() {
   const screenH = typeof window !== 'undefined' ? window.innerHeight : 0;
   const bgOpacity = 1 - Math.min(1, (dragOffset.y / (screenH || 1)) * 2);
   const clamp = (v: number, min: number, max: number) => Math.min(Math.max(v, min), max);
+
+  useEffect(() => {
+    if (promptRef.current) {
+      const el = promptRef.current;
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`;
+    }
+  }, [prompt]);
 
   useEffect(() => {
     const saved = typeof window !== 'undefined' ? localStorage.getItem('aspectRatio') : null;
@@ -534,7 +543,8 @@ export default function Home() {
       <div className="fixed bottom-16 left-0 right-0 p-4 bg-white">
         <div className="flex items-center gap-2">
           <div className="relative flex-1">
-            <input
+            <textarea
+              ref={promptRef}
               value={prompt}
               onChange={(e) => {
                 const value = e.target.value;
@@ -543,7 +553,8 @@ export default function Home() {
                 setOptions(featureOptions.filter(opt => parts.includes(opt)));
               }}
               placeholder="Opisz kuchnię"
-              className="w-full rounded-full px-4 py-2 pr-10 bg-[#f2f2f2] border-none"
+              rows={1}
+              className="w-full rounded-xl px-4 py-2 pr-10 bg-[#f2f2f2] border-none resize-none overflow-hidden"
             />
             <button
               onClick={() => setMenuOpen((o) => !o)}
@@ -572,13 +583,15 @@ export default function Home() {
               </svg>
             </button>
           </div>
-          <button
-            onClick={handleGenerate}
-            disabled={loading}
-            className="border rounded-full px-4 py-2"
-          >
-            {loading ? 'Generuję...' : 'Generuj'}
-          </button>
+          {prompt.trim().length > 0 && (
+            <button
+              onClick={handleGenerate}
+              disabled={loading}
+              className="border rounded-full px-4 py-2"
+            >
+              {loading ? 'Generuję...' : 'Generuj'}
+            </button>
+          )}
         </div>
       </div>
 
@@ -630,13 +643,15 @@ export default function Home() {
             </div>
           </div>
 
-          <button
-            onClick={() => { setMenuOpen(false); handleGenerate(); }}
-            disabled={loading}
-            className="border rounded-full px-4 py-2 mt-4"
-          >
-            {loading ? 'Generuję...' : 'Generuj'}
-          </button>
+          {prompt.trim().length > 0 && (
+            <button
+              onClick={() => { setMenuOpen(false); handleGenerate(); }}
+              disabled={loading}
+              className="border rounded-full px-4 py-2 mt-4"
+            >
+              {loading ? 'Generuję...' : 'Generuj'}
+            </button>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- grow kitchen description textarea automatically with user input
- show the generate button only after the user starts typing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c6f485d088832990184f607cd9c37a