### PR TITLE
Fix bottom nav gap

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -26,8 +26,8 @@ export default function BottomNav() {
           </div>
         </div>
       )}
-      <nav className="fixed bottom-0 left-0 right-0 bg-white border-t z-50">
-        <ul className="flex justify-around py-2 text-xs">
+      <nav className="fixed bottom-0 left-0 right-0 bg-white border-t z-50 h-16">
+        <ul className="flex justify-around items-center h-full text-xs">
           <li>
             <button
               onClick={() => setMenuOpen(true)}


### PR DESCRIPTION
## Summary
- Ensure bottom navigation bar spans 4rem height and aligns with the "Opisz kuchnię" input bar to remove visible gap

## Testing
- `npm test` *(fails: Missing script "test")*
- `ESLINT_USE_FLAT_CONFIG=true npm run lint` *(fails: Failed to patch ESLint)*

------
https://chatgpt.com/codex/tasks/task_b_68c6fa7763688329bb6d369b08e30529