### PR TITLE
Adjust menu and description spacing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -538,7 +538,7 @@ export default function Home() {
         </section>
       )}
 
-      <div className="fixed bottom-16 left-0 right-0 p-4 bg-white">
+      <div className="fixed bottom-16 left-0 right-0 px-4 py-2 bg-white">
         <div className="flex items-center gap-2">
           <div className="relative flex-1">
             <input

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -26,7 +26,7 @@ export default function BottomNav() {
           </div>
         </div>
       )}
-      <nav className="fixed bottom-0 left-0 right-0 bg-white border-t z-50 h-16">
+      <nav className="fixed bottom-0 left-0 right-0 bg-white z-50 h-16">
         <ul className="flex justify-around items-center h-full text-xs">
           <li>
             <button


### PR DESCRIPTION
## Summary
- remove top border from bottom navigation
- tighten spacing around kitchen description input

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c6fbacca188329bc23e37af8bf37a8