### PR TITLE
Show generate button after prompt input

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -579,13 +579,15 @@ export default function Home() {
               </svg>
             </button>
           </div>
-          <button
-            onClick={handleGenerate}
-            disabled={loading}
-            className="border rounded-full px-4 py-2"
-          >
-            {loading ? 'Generuję...' : 'Generuj'}
-          </button>
+          {prompt.trim().length > 0 && (
+            <button
+              onClick={handleGenerate}
+              disabled={loading}
+              className="border rounded-full px-4 py-2"
+            >
+              {loading ? 'Generuję...' : 'Generuj'}
+            </button>
+          )}
         </div>
       </div>
 
@@ -658,16 +660,18 @@ export default function Home() {
           </div>
         </div>
 
-        <button
-          onClick={() => {
-            setMenuOpen(false);
-            handleGenerate();
-          }}
-          disabled={loading}
-          className="border rounded-full px-4 py-2 mt-4"
-        >
-          {loading ? 'Generuję...' : 'Generuj'}
-        </button>
+        {prompt.trim().length > 0 && (
+          <button
+            onClick={() => {
+              setMenuOpen(false);
+              handleGenerate();
+            }}
+            disabled={loading}
+            className="border rounded-full px-4 py-2 mt-4"
+          >
+            {loading ? 'Generuję...' : 'Generuj'}
+          </button>
+        )}
       </div>
 
       {fullscreenIndex !== null && projects[fullscreenIndex] && (


### PR DESCRIPTION
## Summary
- Hide the Generate button until a kitchen prompt is entered
- Apply the same conditional logic in the options menu

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c6fbda10288329ad6485183b3cb6eb