### PR TITLE
Center and animate scroll-to-top button

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -22,11 +22,12 @@ export default function ScrollToTop() {
     <button
       onClick={scrollTop}
       aria-label="Scroll to top"
-      className={`fixed right-4 top-4 z-50 p-2 rounded-full bg-gray-800 text-white transition-transform duration-300 ${
-        visible ? 'translate-y-0' : '-translate-y-full'
+      className={`fixed left-1/2 -translate-x-1/2 top-4 z-50 flex items-center gap-2 px-4 py-2 rounded-full border border-gray-300 bg-white text-gray-800 shadow transition-all duration-300 ${
+        visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4 pointer-events-none'
       }`}
     >
-      ▲
+      <span className="text-lg">↑</span>
+      <span className="text-sm font-medium">To Top</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Center scroll-to-top button with arrow and label
- Show/hide button with fade and slide animation after scrolling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c6fdb1f1548329b48700ed965cef7f