### PR TITLE
fix: raise prompt menu above bottom bar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -601,7 +601,7 @@ export default function Home() {
 
       {/* Sliding menu */}
       <div
-        className={`fixed bottom-0 left-0 right-0 z-50 p-4 bg-white rounded-t-2xl shadow-lg max-h-[75%] overflow-y-auto transform transition-transform duration-300 ${
+        className={`fixed bottom-16 left-0 right-0 z-50 p-4 bg-white rounded-t-2xl shadow-lg max-h-[75%] overflow-y-auto transform transition-transform duration-300 ${
           menuOpen ? 'translate-y-0' : 'translate-y-full'
         }`}
       >


### PR DESCRIPTION
## Summary
- adjust sliding prompt menu to sit above the bottom navigation bar

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c6fe2f43908329894c1b533ae1f9b2