### PR TITLE
Add pulsating border while generating

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -583,7 +583,7 @@ export default function Home() {
             <button
               onClick={handleGenerate}
               disabled={loading}
-              className="border rounded-full px-4 py-2"
+              className={`rounded-full px-4 py-2 ${loading ? 'border-2 border-blue-500 pulse-border' : 'border'}`}
             >
               {loading ? 'Generuję...' : 'Generuj'}
             </button>
@@ -667,7 +667,7 @@ export default function Home() {
               handleGenerate();
             }}
             disabled={loading}
-            className="border rounded-full px-4 py-2 mt-4"
+            className={`rounded-full px-4 py-2 mt-4 ${loading ? 'border-2 border-blue-500 pulse-border' : 'border'}`}
           >
             {loading ? 'Generuję...' : 'Generuj'}
           </button>
@@ -749,6 +749,15 @@ export default function Home() {
           </div>
         </div>
       )}
+      <style jsx>{`
+        @keyframes pulse-border {
+          0%, 100% { border-color: rgba(59, 130, 246, 1); }
+          50% { border-color: rgba(59, 130, 246, 0); }
+        }
+        .pulse-border {
+          animation: pulse-border 1s ease-in-out infinite;
+        }
+      `}</style>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Add blue pulsating outline to "Generuj" buttons when loading
- Implement CSS keyframes for pulse-border animation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Failed to patch ESLint because the calling module was not recognized)


------
https://chatgpt.com/codex/tasks/task_b_68c700322a688329bdbcd2a1a85383de