### PR TITLE
Reduce Scroll-to-Top button size

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -22,12 +22,12 @@ export default function ScrollToTop() {
     <button
       onClick={scrollTop}
       aria-label="Scroll to top"
-      className={`fixed left-1/2 -translate-x-1/2 top-4 z-50 flex items-center gap-2 px-4 py-2 rounded-full border border-gray-300 bg-white text-gray-800 shadow transition-all duration-300 ${
+      className={`fixed left-1/2 -translate-x-1/2 top-4 z-50 flex items-center gap-1 px-2 py-1 rounded-full border border-gray-300 bg-white text-gray-800 shadow transition-all duration-300 ${
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4 pointer-events-none'
       }`}
     >
-      <span className="text-lg">↑</span>
-      <span className="text-sm font-medium">To Top</span>
+      <span className="text-sm">↑</span>
+      <span className="text-xs font-medium">To Top</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Halve spacing and text size of the ScrollToTop button for a less obtrusive control

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c700e25f7083298e0b23760ea41c1e