### PR TITLE
Slow down generate button pulse

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -773,7 +773,7 @@ export default function Home() {
           50% { border-color: rgba(59, 130, 246, 0); }
         }
         .pulse-border {
-          animation: pulse-border 1s ease-in-out infinite;
+          animation: pulse-border 3s ease-in-out infinite;
         }
       `}</style>
     </main>


### PR DESCRIPTION
## Summary
- Slow the `pulse-border` animation to a 3s cycle so the `Generuj` button blinks more calmly.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c703ee649c8329b43842857d510e13