### PR TITLE
Reduce rounding on generate button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -601,7 +601,7 @@ export default function Home() {
             <button
               onClick={handleGenerate}
               disabled={loading}
-              className={`rounded-full px-4 py-2 ${loading ? 'border-2 border-blue-500 pulse-border' : 'border'}`}
+              className={`rounded-md px-4 py-2 ${loading ? 'border-2 border-blue-500 pulse-border' : 'border'}`}
             >
               {loading ? 'Generuję...' : 'Generuj'}
             </button>
@@ -685,7 +685,7 @@ export default function Home() {
               handleGenerate();
             }}
             disabled={loading}
-            className={`rounded-full px-4 py-2 mt-4 ${loading ? 'border-2 border-blue-500 pulse-border' : 'border'}`}
+            className={`rounded-md px-4 py-2 mt-4 ${loading ? 'border-2 border-blue-500 pulse-border' : 'border'}`}
           >
             {loading ? 'Generuję...' : 'Generuj'}
           </button>


### PR DESCRIPTION
## Summary
- use smaller `rounded-md` styling for the generate button

## Testing
- `npm test` (missing script: test)
- `npm run lint` (Failed to patch ESLint because the calling module was not recognized)

------
https://chatgpt.com/codex/tasks/task_b_68c70406ee188329982139ee8a31f0c5