### PR TITLE
style: match generate button styling to input

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -550,7 +550,7 @@ export default function Home() {
       )}
 
       <div className="fixed bottom-16 left-0 right-0 px-4 py-2 bg-white">
-        <div className="flex items-center gap-2">
+        <div className="flex items-stretch gap-2">
           <div className="relative flex-1">
             <textarea
               ref={textareaRef}
@@ -597,7 +597,7 @@ export default function Home() {
             <button
               onClick={handleGenerate}
               disabled={loading}
-              className={`rounded-full px-4 py-2 ${loading ? 'border-2 border-blue-500 pulse-border' : 'border'}`}
+              className={`rounded-xl px-4 py-2 bg-[#f2f2f2] self-stretch flex items-center justify-center ${loading ? 'border-2 border-blue-500 pulse-border' : ''}`}
             >
               {loading ? 'Generuję...' : 'Generuj'}
             </button>


### PR DESCRIPTION
## Summary
- Stretch bottom controls container so generate button aligns with prompt field
- Style generate button with same rounded background as prompt field

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c708f78f308329844c8a7122cdb56f