### PR TITLE
Align description textarea with generate button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -564,7 +564,7 @@ export default function Home() {
                 setOptions(featureOptions.filter(opt => parts.includes(opt)));
               }}
               placeholder="Opisz kuchnię"
-              className="w-full rounded-xl px-4 py-2 pr-10 bg-[#f2f2f2] border-none resize-none overflow-hidden"
+              className="w-full rounded-xl px-4 py-2 pr-10 bg-[#f2f2f2] border-none resize-none overflow-hidden min-h-10"
             />
             <button
               onClick={() => setMenuOpen((o) => !o)}


### PR DESCRIPTION
## Summary
- ensure the "Opisz kuchnię" textarea matches the generate button height

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c70b16b9fc832983ce1c5e4217fe1c