### PR TITLE
Adjust spacing for prompt input

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -577,7 +577,7 @@ export default function Home() {
         </section>
       )}
 
-      <div className="fixed bottom-16 left-0 right-0 px-4 py-2 bg-white">
+      <div className="fixed bottom-4 left-0 right-0 px-4 py-2 bg-white">
         <div className="flex items-stretch gap-2">
           <div className={`relative flex-1 rounded-xl ${loading ? 'led-border' : ''}`}>
             <textarea
@@ -659,7 +659,7 @@ export default function Home() {
 
       {/* Sliding menu */}
       <div
-        className={`fixed bottom-16 left-0 right-0 z-50 p-4 bg-white rounded-t-2xl shadow-lg max-h-[75%] overflow-y-auto transform transition-transform duration-300 ${
+        className={`fixed bottom-8 left-0 right-0 z-50 p-4 bg-white rounded-t-2xl shadow-lg max-h-[75%] overflow-y-auto transform transition-transform duration-300 ${
           menuOpen ? 'translate-y-0' : 'translate-y-full'
         }`}
       >


### PR DESCRIPTION
## Summary
- Move the "Opisz kuchnię" input closer to the bottom edge
- Offset the sliding menu to maintain even spacing above the input

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint module)*
- `npm run build` *(fails: Unable to fetch Geist fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_b_68c725752d4c83299676362eb11511e6