### PR TITLE
Hide send icon until prompt is filled

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -626,7 +626,11 @@ export default function Home() {
             <button
               onClick={handleGenerate}
               disabled={loading || !hasPrompt}
-              className={`absolute right-2 top-1/2 -translate-y-1/2 p-2 transition-all duration-300 disabled:opacity-50 ${hasPrompt ? 'opacity-100 scale-100' : 'opacity-0 scale-90 pointer-events-none'}`}
+              className={`absolute right-2 top-1/2 -translate-y-1/2 p-2 transition-all duration-300 ${
+                hasPrompt
+                  ? 'opacity-100 scale-100 disabled:opacity-50'
+                  : 'opacity-0 scale-90 pointer-events-none'
+              }`}
               aria-label="Wyślij"
             >
               <svg


### PR DESCRIPTION
## Summary
- show the send icon only when text is present, avoiding overlap with the settings icon

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Failed to patch ESLint because the calling module was not recognized)


------
https://chatgpt.com/codex/tasks/task_b_68c81f883f648329869c3c1088af1a74