### PR TITLE
Clamp pan during pinch zoom

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -176,6 +176,12 @@ export default function Home() {
       const dist = Math.hypot(dx, dy);
       const newScale = clamp((dist / pinchStartDist.current) * baseScale.current, 1, 4);
       setScale(newScale);
+      const maxX = (screenW * (newScale - 1)) / 2;
+      const maxY = (screenH * (newScale - 1)) / 2;
+      const clampedX = clamp(pan.x, -maxX, maxX);
+      const clampedY = clamp(pan.y, -maxY, maxY);
+      setPan({ x: clampedX, y: clampedY });
+      basePan.current = { x: clampedX, y: clampedY };
     } else if (scale > 1 && e.touches.length === 1 && lastPanTouch.current) {
       const currentX = e.touches[0].clientX;
       const currentY = e.touches[0].clientY;


### PR DESCRIPTION
## Summary
- keep fullscreen images against screen edges while pinch zooming

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c8225d0c2c8329b64105c9aefa65cd