### PR TITLE
Adjust description bar position

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -577,7 +577,7 @@ export default function Home() {
         </section>
       )}
 
-      <div className="fixed bottom-16 left-0 right-0 px-4 py-2 bg-white">
+      <div className="fixed bottom-[2px] left-0 right-0 px-4 py-2 bg-white">
         <div className="flex items-stretch gap-2">
           <div className={`relative flex-1 rounded-xl ${loading ? 'led-border' : ''}`}>
             <textarea
@@ -661,7 +661,7 @@ export default function Home() {
 
       {/* Sliding menu */}
       <div
-        className={`fixed bottom-16 left-0 right-0 z-50 p-4 bg-white rounded-t-2xl shadow-lg max-h-[75%] overflow-y-auto transform transition-transform duration-300 ${
+        className={`fixed bottom-[2px] left-0 right-0 z-50 p-4 bg-white rounded-t-2xl shadow-lg max-h-[75%] overflow-y-auto transform transition-transform duration-300 ${
           menuOpen ? 'translate-y-0' : 'translate-y-full'
         }`}
       >


### PR DESCRIPTION
## Summary
- Move "Opisz kuchnię" description input bar 62px closer to the bottom menu
- Align sliding options menu with new input bar position

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c823677b2083299facba2f595ddd99