### PR TITLE
Remove white background under kitchen description field

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -609,10 +609,10 @@ export default function Home() {
         </section>
       )}
 
-      <div className="fixed bottom-16 left-0 right-0 px-4 py-2 bg-white">
-        <div className="flex items-stretch gap-2">
-          <div className={`relative flex-1 rounded-xl ${loading ? 'led-border' : ''}`}>
-            <textarea
+        <div className="fixed bottom-16 left-0 right-0 px-4 py-2">
+          <div className="flex items-stretch gap-2">
+            <div className={`relative flex-1 rounded-xl ${loading ? 'led-border' : ''}`}>
+              <textarea
               ref={textareaRef}
               rows={1}
               value={prompt}


### PR DESCRIPTION
## Summary
- avoid white container background around "Opisz kuchnię" input so only the gray textarea is visible

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c8272c5e8483298118419db238c361