### PR TITLE
Fix textarea initial height expansion

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -102,9 +102,11 @@ export default function Home() {
     const lineHeight = parseFloat(getComputedStyle(el).lineHeight);
     const maxHeight = lineHeight * 4;
     el.style.height = 'auto';
-    const newHeight = Math.min(el.scrollHeight, maxHeight);
+    const scrollHeight = el.scrollHeight;
+    const desiredHeight = el.value ? scrollHeight : lineHeight;
+    const newHeight = Math.min(desiredHeight, maxHeight);
     el.style.height = `${newHeight}px`;
-    el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden';
+    el.style.overflowY = el.value && scrollHeight > maxHeight ? 'auto' : 'hidden';
   };
   useEffect(() => { autoResize(); }, [prompt]);
   useEffect(() => { autoResize(); }, []); // na wszelki wypadek po montażu


### PR DESCRIPTION
## Summary
- ensure textarea starts at single-line height by ignoring placeholder in auto-resize

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Failed to patch ESLint)


------
https://chatgpt.com/codex/tasks/task_b_68c82e762bb083298fbee5e34af6e30e