### PR TITLE
Animate placeholder text on load

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,20 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes placeholderSlideIn {
+  from {
+    text-indent: -100%;
+    opacity: 0;
+  }
+  to {
+    text-indent: 0;
+    opacity: 1;
+  }
+}
+
+.placeholder-slide-in::placeholder {
+  text-indent: -100%;
+  opacity: 0;
+  animation: placeholderSlideIn 0.6s ease forwards;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -648,7 +648,7 @@ export default function Home() {
                 setOptions(featureOptions.filter(opt => parts.includes(opt)));
               }}
               placeholder={PROMPT_PLACEHOLDER}
-              className={`w-full rounded-xl px-4 py-3 ${hasPrompt ? 'pr-20' : 'pr-12'} bg-[#f2f2f2] border-none resize-none min-h-12 text-lg overflow-y-auto transition-all duration-300`}
+              className={`w-full rounded-xl px-4 py-3 ${hasPrompt ? 'pr-20' : 'pr-12'} bg-[#f2f2f2] border-none resize-none min-h-12 text-lg overflow-y-auto transition-all duration-300 placeholder-slide-in`}
             />
             <button
               onClick={() => setMenuOpen((o) => !o)}


### PR DESCRIPTION
## Summary
- animate "Opisz kuchnię" placeholder by sliding in on page load
- add CSS keyframes and apply placeholder class

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68c82fc507f88329ac9af65c42dbc0ef