### PR TITLE
Autofill kitchen description when copying prompt

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -827,7 +827,15 @@ export default function Home() {
               className={`text-white text-sm bg-black/60 p-2 rounded-md break-words border cursor-pointer ${copied ? 'border-white' : 'border-transparent'}`}
               onClick={(e) => {
                 e.stopPropagation();
-                navigator.clipboard.writeText(projects[fullscreenIndex].prompt);
+                const text = projects[fullscreenIndex].prompt;
+                navigator.clipboard.writeText(text);
+                setPrompt(text);
+                if (typeof window !== 'undefined') {
+                  sessionStorage.setItem('promptDraft', text);
+                }
+                const parts = text.split(',').map(p => p.trim());
+                setOptions(featureOptions.filter(opt => parts.includes(opt)));
+                autoResize();
                 setCopied(true);
                 setTimeout(() => setCopied(false), 1000);
               }}


### PR DESCRIPTION
## Summary
- Paste image prompt into the "Opisz kuchnię" field when copying from fullscreen view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Failed to patch ESLint)*

------
https://chatgpt.com/codex/tasks/task_b_68c8316d7b808329a7b1d1c851aaff79