### PR TITLE
Use fade-in for kitchen description placeholder

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,19 +25,16 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
-@keyframes placeholderSlideIn {
+@keyframes placeholderFadeIn {
   from {
-    text-indent: -100%;
     opacity: 0;
   }
   to {
-    text-indent: 0;
     opacity: 1;
   }
 }
 
-.placeholder-slide-in::placeholder {
-  text-indent: -100%;
+.placeholder-fade-in::placeholder {
   opacity: 0;
-  animation: placeholderSlideIn 0.6s ease forwards;
+  animation: placeholderFadeIn 0.6s ease forwards;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -648,7 +648,7 @@ export default function Home() {
                 setOptions(featureOptions.filter(opt => parts.includes(opt)));
               }}
               placeholder={PROMPT_PLACEHOLDER}
-              className={`w-full rounded-xl px-4 py-3 ${hasPrompt ? 'pr-20' : 'pr-12'} bg-[#f2f2f2] border-none resize-none min-h-12 text-lg overflow-y-auto transition-all duration-300 placeholder-slide-in`}
+              className={`w-full rounded-xl px-4 py-3 ${hasPrompt ? 'pr-20' : 'pr-12'} bg-[#f2f2f2] border-none resize-none min-h-12 text-lg overflow-y-auto transition-all duration-300 placeholder-fade-in`}
             />
             <button
               onClick={() => setMenuOpen((o) => !o)}


### PR DESCRIPTION
## Summary
- fade in placeholder text instead of sliding animation
- update textarea class to use new fade-in style

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Error: Failed to patch ESLint because the calling module was not recognized.)*

------
https://chatgpt.com/codex/tasks/task_b_68c8322f904883298bbf34b1504734b1