### PR TITLE
Dismiss keyboard on outside tap

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -125,6 +125,27 @@ export default function Home() {
     setCollapsedWidth(textWidth + paddingLeft + paddingRight);
   }, []);
 
+  useEffect(() => {
+    const handleOutsideTap = (e: MouseEvent | TouchEvent) => {
+      const textarea = textareaRef.current;
+      if (
+        textarea &&
+        document.activeElement === textarea &&
+        !textarea.contains(e.target as Node)
+      ) {
+        textarea.blur();
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+    document.addEventListener('mousedown', handleOutsideTap, true);
+    document.addEventListener('touchstart', handleOutsideTap, true);
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideTap, true);
+      document.removeEventListener('touchstart', handleOutsideTap, true);
+    };
+  }, []);
+
   // --- gestures / fullscreen ---
   const touchStartX = useRef<number | null>(null);
   const touchStartY = useRef<number | null>(null);


### PR DESCRIPTION
## Summary
- hide kitchen description keyboard when tapping outside the field

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Failed to patch ESLint because the calling module was not recognized)

------
https://chatgpt.com/codex/tasks/task_b_68c83591f580832985cd9643b9513ee0