### PR TITLE
Simplify kitchen style options

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,15 +26,7 @@ function uuidish() {
 export default function Home() {
   const [prompt, setPrompt] = useState('');
   const [options, setOptions] = useState<string[]>([]);
-  const featureOptions = [
-    'Lodówka z prawej',
-    'Lodówka z lewej',
-    'Zlew pod oknem',
-    'Piekarnik w słupku',
-    'Nowoczesna',
-    'Klasyczna',
-    'Bezuchwytów',
-  ];
+  const featureOptions = ['Nowoczesna', 'Klasyczna'];
 
   const toggleOption = (opt: string) => {
     setOptions(prev =>
@@ -757,7 +749,7 @@ export default function Home() {
         </div>
 
         <div className="flex-1">
-          <p className="font-medium mb-2">Opcje</p>
+          <p className="font-medium mb-2">Styl kuchni</p>
           <div className="flex flex-wrap gap-2">
             {featureOptions.map((f) => (
               <button


### PR DESCRIPTION
## Summary
- limit the available prompt style options to just Nowoczesna and Klasyczna
- relabel the prompt options section header to "Styl kuchni" for clarity

## Testing
- npm run lint *(fails: ESLint patch module not recognized in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c85ed07cb4832998fbc4e11267ff6a