### PR TITLE
Adjust prompt settings send button placement

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,7 +43,7 @@ const LAYOUT_FEATURE_OPTIONS: FeatureOption[] = [
   { label: 'I', promptText: 'Kuchnia na jednej ścianie' },
   { label: 'L', promptText: 'Kuchnia w literę L' },
   { label: 'U', promptText: 'Kuchnia w literę U' },
-  { label: 'I I', promptText: 'Kuchnia na dwóch równoległych ścianach' },
+  { label: 'I I', promptText: 'Kuchnia na dwóch równoległych ścianach nie połączonych ze sobą meblami' },
   { label: 'Wyspa', promptText: 'Kuchnia z wyspą' },
   { label: 'Barek', promptText: 'Kuchnia z barkiem do siedzenia pod hokery' },
 ];
@@ -801,31 +801,60 @@ export default function Home() {
 
         <div className="mb-4">
           <p className="font-medium mb-2">Orientacja</p>
-          <div className="flex gap-2 flex-wrap">
-            <button
-              onClick={() => selectAspect('3:4')}
-              className={`px-3 py-1 rounded-full text-sm ${
-                aspectRatio === '3:4' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
-              }`}
-            >
-              Pion 4:3
-            </button>
-            <button
-              onClick={() => selectAspect('1:1')}
-              className={`px-3 py-1 rounded-full text-sm ${
-                aspectRatio === '1:1' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
-              }`}
-            >
-              Kwadrat
-            </button>
-            <button
-              onClick={() => selectAspect('4:3')}
-              className={`px-3 py-1 rounded-full text-sm ${
-                aspectRatio === '4:3' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
-              }`}
-            >
-              Poziom 4:3
-            </button>
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="flex flex-1 flex-wrap gap-2">
+              <button
+                onClick={() => selectAspect('3:4')}
+                className={`px-3 py-1 rounded-full text-sm ${
+                  aspectRatio === '3:4' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
+                }`}
+              >
+                Pion 4:3
+              </button>
+              <button
+                onClick={() => selectAspect('1:1')}
+                className={`px-3 py-1 rounded-full text-sm ${
+                  aspectRatio === '1:1' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
+                }`}
+              >
+                Kwadrat
+              </button>
+              <button
+                onClick={() => selectAspect('4:3')}
+                className={`px-3 py-1 rounded-full text-sm ${
+                  aspectRatio === '4:3' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
+                }`}
+              >
+                Poziom 4:3
+              </button>
+            </div>
+            <div className="ml-auto flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  if (loading || !hasPrompt) return;
+                  setMenuOpen(false);
+                  handleGenerate();
+                }}
+                disabled={loading || !hasPrompt}
+                className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-[#f2f2f2] text-gray-700 shadow-sm transition disabled:opacity-50 disabled:cursor-not-allowed"
+                aria-label="Wyślij"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="w-5 h-5"
+                >
+                  <path d="M22 2L11 13" />
+                  <path d="M22 2L15 22l-4-9-9-4 20-7z" />
+                </svg>
+              </button>
+            </div>
           </div>
         </div>
 
@@ -848,34 +877,6 @@ export default function Home() {
               </div>
             </div>
           ))}
-        </div>
-
-        <div className="mt-6 flex justify-end">
-          <button
-            type="button"
-            onClick={() => {
-              if (loading || !hasPrompt) return;
-              setMenuOpen(false);
-              handleGenerate();
-            }}
-            disabled={loading || !hasPrompt}
-            className="flex h-12 w-12 items-center justify-center rounded-full bg-[#f2f2f2] text-gray-700 shadow-sm transition disabled:opacity-50 disabled:cursor-not-allowed"
-            aria-label="Wyślij"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="w-5 h-5"
-            >
-              <path d="M22 2L11 13" />
-              <path d="M22 2L15 22l-4-9-9-4 20-7z" />
-            </svg>
-          </button>
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- align the send button inside the prompt settings sheet with the layout options instead of a standalone bottom row
- update the "I I" layout option description to mention the parallel walls are not connected by cabinetry

## Testing
- npm run lint *(fails: Failed to patch ESLint because the calling module was not recognized.)*

------
https://chatgpt.com/codex/tasks/task_b_68c86d91e36c8329ba0df82e204ead97