### PR TITLE
Reposition send icon within settings panel

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -753,7 +753,7 @@ export default function Home() {
       <div
         className={`fixed bottom-16 left-0 right-0 z-50 p-4 bg-white rounded-t-2xl shadow-lg max-h-[75%] overflow-y-auto transform transition-transform duration-300 ${
           menuOpen ? 'translate-y-0' : 'translate-y-full'
-        }`}
+        } pb-20`}
       >
         <button
           className="absolute top-3 right-3 flex h-12 w-12 items-center justify-center rounded-full bg-[#f2f2f2] text-3xl leading-none text-gray-600 shadow-sm"
@@ -765,60 +765,31 @@ export default function Home() {
 
         <div className="mb-4">
           <p className="font-medium mb-2">Orientacja</p>
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="flex flex-1 flex-wrap gap-2">
-              <button
-                onClick={() => selectAspect('3:4')}
-                className={`px-3 py-1 rounded-full text-sm ${
-                  aspectRatio === '3:4' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
-                }`}
-              >
-                Pion 4:3
-              </button>
-              <button
-                onClick={() => selectAspect('1:1')}
-                className={`px-3 py-1 rounded-full text-sm ${
-                  aspectRatio === '1:1' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
-                }`}
-              >
-                Kwadrat
-              </button>
-              <button
-                onClick={() => selectAspect('4:3')}
-                className={`px-3 py-1 rounded-full text-sm ${
-                  aspectRatio === '4:3' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
-                }`}
-              >
-                Poziom 4:3
-              </button>
-            </div>
-            <div className="ml-auto flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => {
-                  if (loading || !hasPrompt) return;
-                  setMenuOpen(false);
-                  handleGenerate();
-                }}
-                disabled={loading || !hasPrompt}
-                className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-[#f2f2f2] text-gray-700 shadow-sm transition disabled:opacity-50 disabled:cursor-not-allowed"
-                aria-label="Wyślij"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="w-5 h-5"
-                >
-                  <path d="M22 2L11 13" />
-                  <path d="M22 2L15 22l-4-9-9-4 20-7z" />
-                </svg>
-              </button>
-            </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => selectAspect('3:4')}
+              className={`px-3 py-1 rounded-full text-sm ${
+                aspectRatio === '3:4' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
+              }`}
+            >
+              Pion 4:3
+            </button>
+            <button
+              onClick={() => selectAspect('1:1')}
+              className={`px-3 py-1 rounded-full text-sm ${
+                aspectRatio === '1:1' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
+              }`}
+            >
+              Kwadrat
+            </button>
+            <button
+              onClick={() => selectAspect('4:3')}
+              className={`px-3 py-1 rounded-full text-sm ${
+                aspectRatio === '4:3' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
+              }`}
+            >
+              Poziom 4:3
+            </button>
           </div>
         </div>
 
@@ -841,6 +812,34 @@ export default function Home() {
               </div>
             </div>
           ))}
+        </div>
+
+        <div className="absolute bottom-4 right-4">
+          <button
+            type="button"
+            onClick={() => {
+              if (loading || !hasPrompt) return;
+              setMenuOpen(false);
+              handleGenerate();
+            }}
+            disabled={loading || !hasPrompt}
+            className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-[#f2f2f2] text-gray-700 shadow-sm transition disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="Wyślij"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="w-5 h-5"
+            >
+              <path d="M22 2L11 13" />
+              <path d="M22 2L15 22l-4-9-9-4 20-7z" />
+            </svg>
+          </button>
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- move the Wyślij button in the settings drawer to a fixed bottom-right placement so it aligns with the bottom options
- simplify the orientation selector layout now that the action button is no longer embedded in the pill list
- add extra bottom padding to the drawer so scrolling content does not overlap the floating action button

## Testing
- `npm run lint` *(fails: ESLint patch cannot be applied in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c86fd0726483298f956f45697bfabb