### PR TITLE
Rename orientation prompt setting label

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -805,7 +805,7 @@ export default function Home() {
         </button>
 
         <div className="mb-4">
-          <p className="font-medium mb-2">Orientacja</p>
+          <p className="font-medium mb-2">Proporcje zdjęcia</p>
           <div className="flex flex-wrap gap-2">
             <button
               onClick={() => selectAspect('3:4')}


### PR DESCRIPTION
## Summary
- rename the prompt settings label from "Orientacja" to "Proporcje zdjęcia" to clarify it reflects photo proportions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c8753b07d483298a8284a164f1bb25