### PR TITLE
Update prompt size labels

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -88,8 +88,8 @@ const APPLIANCE_FEATURE_OPTIONS: FeatureOption[] = [
 const SIZE_FEATURE_OPTIONS: FeatureOption[] = [
   { label: 'XS', promptText: 'Mała kuchnia ciasna w bloku' },
   { label: 'S', promptText: 'Niezaduża kuchnia w mieszkaniu' },
-  { label: 'M', promptText: 'Średnia kuchnia do mieszkania' },
-  { label: 'L', promptText: 'Kuchnia duża do domu' },
+  { label: 'Medium', promptText: 'Średnia kuchnia do mieszkania' },
+  { label: 'Large', promptText: 'Kuchnia duża do domu' },
   { label: 'XL', promptText: 'Bardzo duża kuchnia najczęściej z wyspą do domu' },
 ];
 


### PR DESCRIPTION
## Summary
- rename the size options in prompt settings from single letters to "Medium" and "Large"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c87eb2be4c8329ab5470e910033cc2