### PR TITLE
Ensure fullscreen prompt description uses full height

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -948,7 +948,9 @@ export default function Home() {
             <div
               className={`text-white text-sm bg-black/60 p-2 rounded-md break-words border ${copied ? 'border-white' : 'border-transparent'} max-h-20 overflow-y-auto`}
             >
-              <p>{projects[fullscreenIndex].prompt}</p>
+              <p className="m-0 leading-5 whitespace-pre-wrap">
+                {projects[fullscreenIndex].prompt}
+              </p>
             </div>
             <div className="flex justify-end gap-2">
               <button


### PR DESCRIPTION
## Summary
- remove default paragraph margin and enforce consistent line height in the fullscreen prompt description
- preserve whitespace so the prompt text renders cleanly inside the four-line container

## Testing
- npm run lint *(fails: `@rushstack/eslint-patch` cannot patch ESLint 9 in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c88acca0b0832987e1d26ebf42e979