### PR TITLE
Avoid reopening keyboard after menu-based generation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -539,7 +539,7 @@ export default function Home() {
   }, [fullscreenIndex, projects.length]);
 
   // --- GENEROWANIE + ZAPIS ---
-  const handleGenerate = async () => {
+  const handleGenerate = async ({ focusTextarea = true }: { focusTextarea?: boolean } = {}) => {
     if (!user) { alert('Zaloguj się!'); return; }
     const optionPrompts = options
       .map((label) => optionPromptByLabel(label))
@@ -565,7 +565,11 @@ export default function Home() {
     if (typeof window !== 'undefined') {
       sessionStorage.removeItem('promptDraft');
     }
-    textareaRef.current?.focus();
+    if (focusTextarea) {
+      textareaRef.current?.focus();
+    } else {
+      textareaRef.current?.blur();
+    }
     try {
       const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
       if (sessionError) { throw sessionError; }
@@ -794,7 +798,7 @@ export default function Home() {
               </svg>
             </button>
             <button
-              onClick={handleGenerate}
+              onClick={() => { void handleGenerate(); }}
               disabled={loading || !hasPrompt}
               className={`absolute right-2 top-1/2 -translate-y-1/2 p-2 transition-all duration-300 ${
                 hasPrompt
@@ -900,7 +904,7 @@ export default function Home() {
             onClick={() => {
               if (loading || !hasSelectedOptions) return;
               setMenuOpen(false);
-              handleGenerate();
+              void handleGenerate({ focusTextarea: false });
             }}
             disabled={loading || !hasSelectedOptions}
             className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-[#f2f2f2] ${


### PR DESCRIPTION
## Summary
- allow the generator handler to skip refocusing the prompt textarea
- keep the textarea blurred when sending a prompt from the settings menu so the mobile keyboard hides
- wrap the main send button handler to preserve the existing focus behaviour

## Testing
- npm run lint *(fails: ESLint patch module could not be applied in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cc1ab0fff08329b0e7edc4771cf7ff