### PR TITLE
Adjust gallery layout to grid with responsive columns

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -712,9 +712,9 @@ export default function Home() {
       {showEmptyState ? (
         <p className="text-gray-500">Na razie pusto – opisz kuchnię i wyślij!</p>
       ) : (
-        <section className="columns-2 md:columns-3 gap-1">
+        <section className="grid grid-cols-2 md:grid-cols-4 gap-1">
           {pendingFrame && (
-            <figure className="mb-1 break-inside-avoid relative">
+            <figure className="relative">
               <div
                 className="relative w-full led-border rounded-xl bg-white shadow-sm"
                 style={{ aspectRatio: pendingFrame.aspectRatio.replace(':', ' / ') }}
@@ -730,7 +730,7 @@ export default function Home() {
           {projects.map((p, i) => (
             <figure
               key={p.id}
-              className="mb-1 break-inside-avoid relative"
+              className="relative"
             >
               <img
                 src={p.imageUrl}


### PR DESCRIPTION
## Summary
- replace the masonry-style columns gallery with a CSS grid so items keep chronological ordering across rows
- update responsive breakpoints so the gallery renders two columns on mobile and four columns on larger screens

## Testing
- npm run lint *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68cc1c72b8b483299337aa0db0f2e30d