### PR TITLE
Rename companies section to contractors

### DIFF
--- a/src/app/firmy/page.tsx
+++ b/src/app/firmy/page.tsx
@@ -126,9 +126,9 @@ export default function FirmyPage() {
 
       <section className="mx-auto mt-12 max-w-6xl space-y-6">
         <header className="space-y-2">
-          <h1 className="text-3xl font-bold text-slate-900">Firmy partnerskie</h1>
+          <h1 className="text-3xl font-bold text-slate-900">Wykonawcy</h1>
           <p className="max-w-3xl text-sm text-slate-600">
-            Poniżej znajdziesz listę firm dostępnych w naszym katalogu. Wersja mapowa
+            Poniżej znajdziesz listę wykonawców dostępnych w naszym katalogu. Wersja mapowa
             umożliwia szybkie wyszukanie partnerów w Twojej okolicy, a lista stanowi
             tekstowy fallback dla wyszukiwarek i użytkowników preferujących klasyczny
             przegląd.

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -67,7 +67,7 @@ export default function BottomNav() {
               }`}
             >
               <span className="text-xl">🏢</span>
-              Firmy
+              Wykonawcy
             </Link>
           </li>
         </ul>


### PR DESCRIPTION
## Summary
- rename the bottom navigation label from "Firmy" to "Wykonawcy"
- update the companies listing page header and description to reference contractors

## Testing
- npm run lint *(fails: @rushstack/eslint-patch cannot patch ESLint 9.35.0)*

------
https://chatgpt.com/codex/tasks/task_b_68cc684452b8832987c08e98a2125395