### PR TITLE
Scroll to top after starting generation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -570,6 +570,10 @@ export default function Home() {
       return;
     }
 
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+
     const userPrompt = prompt; // zapisz oryginalny prompt użytkownika, zanim go wyczyścimy z inputu
     const optionsPrompt = optionPrompts.join(', ');
     const placeholderSource = userPrompt.trim() ? userPrompt : optionsPrompt;


### PR DESCRIPTION
## Summary
- scroll the page to the top whenever generation starts so new results are visible immediately

## Testing
- npm run lint *(fails: Failed to patch ESLint because the calling module was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_68ce66e49ea883299ffb83b4dcd52f28