### PR TITLE
Add Moja kuchnia settings page

### DIFF
--- a/src/app/moja-kuchnia/page.tsx
+++ b/src/app/moja-kuchnia/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+  FEATURE_CATEGORIES,
+  ASPECT_RATIO_STORAGE_KEY,
+  PROMPT_STORAGE_KEY,
+  extractOptionLabelsFromPrompt,
+  mergePromptWithSelectedOptions,
+} from '@/lib/kitchenFeatures';
+
+export default function MojaKuchniaPage() {
+  const [aspectRatio, setAspectRatio] = useState('4:3');
+  const [options, setOptions] = useState<string[]>([]);
+  const [prompt, setPrompt] = useState('');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const savedPrompt = sessionStorage.getItem(PROMPT_STORAGE_KEY);
+    if (savedPrompt) {
+      setPrompt(savedPrompt);
+      setOptions(extractOptionLabelsFromPrompt(savedPrompt));
+    }
+
+    const savedAspect = localStorage.getItem(ASPECT_RATIO_STORAGE_KEY);
+    if (savedAspect) {
+      setAspectRatio(savedAspect);
+    }
+  }, []);
+
+  const selectAspect = (ratio: string) => {
+    setAspectRatio(ratio);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(ASPECT_RATIO_STORAGE_KEY, ratio);
+    }
+  };
+
+  const toggleOption = (label: string) => {
+    setOptions((prev) => {
+      const next = prev.includes(label)
+        ? prev.filter((item) => item !== label)
+        : [...prev, label];
+      setPrompt((prevPrompt) => {
+        const merged = mergePromptWithSelectedOptions(prevPrompt, next);
+        if (typeof window !== 'undefined') {
+          sessionStorage.setItem(PROMPT_STORAGE_KEY, merged);
+        }
+        return merged;
+      });
+      return next;
+    });
+  };
+
+  const clearSelections = () => {
+    setOptions([]);
+    setPrompt((prevPrompt) => {
+      const base = mergePromptWithSelectedOptions(prevPrompt, []);
+      if (typeof window !== 'undefined') {
+        if (base) {
+          sessionStorage.setItem(PROMPT_STORAGE_KEY, base);
+        } else {
+          sessionStorage.removeItem(PROMPT_STORAGE_KEY);
+        }
+      }
+      return base;
+    });
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 pb-24 pt-20">
+      <header className="mb-8">
+        <h1 className="text-4xl font-semibold text-slate-900">Moja kuchnia</h1>
+        <p className="mt-3 text-base text-slate-600">
+          Ustaw swoje ulubione parametry, a zapisane wartości będą czekać w kreatorze generowania kuchni.
+        </p>
+      </header>
+
+      <section className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white p-6 shadow-lg">
+        <div className="mb-6 flex flex-wrap items-center gap-2">
+          <p className="font-medium">Proporcje zdjęcia</p>
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => selectAspect('3:4')}
+              className={`px-3 py-1 rounded-full text-sm ${
+                aspectRatio === '3:4' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
+              }`}
+            >
+              Pion 4:3
+            </button>
+            <button
+              onClick={() => selectAspect('1:1')}
+              className={`px-3 py-1 rounded-full text-sm ${
+                aspectRatio === '1:1' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
+              }`}
+            >
+              Kwadrat
+            </button>
+            <button
+              onClick={() => selectAspect('4:3')}
+              className={`px-3 py-1 rounded-full text-sm ${
+                aspectRatio === '4:3' ? 'bg-blue-200' : 'bg-[#f2f2f2]'
+              }`}
+            >
+              Poziom 4:3
+            </button>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          {FEATURE_CATEGORIES.map((category) => (
+            <div key={category.name}>
+              <p className="font-medium mb-2">{category.name}</p>
+              <div className="flex flex-wrap gap-2">
+                {category.options.map((option) => (
+                  <button
+                    key={option.label}
+                    onClick={() => toggleOption(option.label)}
+                    className={`px-3 py-1 rounded-full text-sm ${
+                      options.includes(option.label) ? 'bg-blue-200' : 'bg-[#f2f2f2]'
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-[#f2f2f2] px-4 py-3 text-sm text-slate-600">
+          <span>Ustawienia zapisują się automatycznie</span>
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={clearSelections}
+              className="rounded-full border border-transparent bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-200 hover:bg-slate-50"
+            >
+              Wyczyść wybory
+            </button>
+            <Link
+              href="/"
+              className="rounded-full bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700"
+            >
+              Otwórz generator
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">Mój zapisany opis kuchni</h2>
+        {prompt ? (
+          <p className="mt-3 whitespace-pre-wrap text-sm leading-relaxed text-slate-600">{prompt}</p>
+        ) : (
+          <p className="mt-3 text-sm text-slate-500">
+            Dodaj opis na stronie głównej, aby zobaczyć go tutaj wraz z wybranymi ustawieniami.
+          </p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,14 @@
 import { useEffect, useState, useRef } from 'react';
 import { supabase } from '@/lib/supabaseClient';
 import { ensureProfile } from '@/lib/profile';
+import {
+  FEATURE_CATEGORIES,
+  mergePromptWithSelectedOptions,
+  extractOptionLabelsFromPrompt,
+  optionPromptByLabel,
+  PROMPT_STORAGE_KEY,
+  ASPECT_RATIO_STORAGE_KEY,
+} from '@/lib/kitchenFeatures';
 
 type Project = {
   id: string;            // id rekordu w DB
@@ -25,109 +33,6 @@ const EVENT_GENERATION_FINISHED = 'generation-finished';
 const PROMPT_PLACEHOLDER = 'Opisz kuchnię';
 const PROMPT_OVERLAY_STORAGE_KEY = 'showPromptOverlayV2';
 
-type FeatureOption = {
-  label: string;
-  promptText: string;
-};
-
-type FeatureCategory = {
-  name: string;
-  options: FeatureOption[];
-};
-
-const STYLE_FEATURE_OPTIONS: FeatureOption[] = [
-  { label: 'Nowoczesna', promptText: 'Kuchnia nowoczesna' },
-  { label: 'Klasyczna', promptText: 'Kuchnia klasyczna' },
-  { label: 'Skandynawska', promptText: 'Kuchnia w stylu skandynawskim' },
-  { label: 'Loft / Industrial', promptText: 'Kuchnia w stylu loft / industrialnym' },
-  { label: 'Rustykalna', promptText: 'Kuchnia rustykalna' },
-  { label: 'Minimalistyczna', promptText: 'Kuchnia minimalistyczna' },
-  { label: 'Glamour', promptText: 'Kuchnia w stylu glamour' },
-  { label: 'Retro', promptText: 'Kuchnia retro' },
-  { label: 'Boho', promptText: 'Kuchnia boho' },
-  { label: 'Japandi', promptText: 'Kuchnia w stylu japandi' },
-];
-
-const LAYOUT_FEATURE_OPTIONS: FeatureOption[] = [
-  { label: 'I', promptText: 'Kuchnia na jednej ścianie' },
-  { label: 'L', promptText: 'Kuchnia w literę L' },
-  { label: 'U', promptText: 'Kuchnia w literę U' },
-  { label: 'I I', promptText: 'Kuchnia na dwóch równoległych ścianach nie połączonych ze sobą meblami' },
-  { label: 'Wyspa', promptText: 'Kuchnia z wyspą' },
-  {
-    label: 'Barek',
-    promptText:
-      'Kuchnia z podwyższonym wąski blatem jako barkiem pod hokery dostawiona do blatu roboczego',
-  },
-];
-
-const APPLIANCE_FEATURE_OPTIONS: FeatureOption[] = [
-  {
-    label: 'Lod zab.',
-    promptText:
-      'Kuchnia z jedną lodówką w zabudowie dwoje drzwi na dole front do wysokości blatu drugi front jak pasuje',
-  },
-  { label: 'Lod. woln.', promptText: 'Kuchnia z lodówką pojedynczą szerokości 60cm wysoką' },
-  { label: 'Lod. side', promptText: 'Kuchnia z lodówką side by side dwoje drzwi szeroka' },
-  {
-    label: 'Piek pod pł.',
-    promptText:
-      'Kuchnia z piekarnikiem pod płytą grzewczą 60cm nad okap wolnowiszący lub w zabudowie',
-  },
-  {
-    label: 'Piek w słup.',
-    promptText:
-      'Kuchnia z piekarnikiem w słupku zazwyczaj razem z mikrofalą też w zabudowie',
-  },
-  {
-    label: 'Zlew okno',
-    promptText:
-      'Kuchnia ze zlewozmywakiem pod oknem najczęściej półtorakomory z małym ociekaczem w kuchni tylko jeden zlew',
-  },
-];
-
-const SIZE_FEATURE_OPTIONS: FeatureOption[] = [
-  { label: 'XS', promptText: 'Mała kuchnia ciasna w bloku' },
-  { label: 'S', promptText: 'Niezaduża kuchnia w mieszkaniu' },
-  { label: 'Medium', promptText: 'Średnia kuchnia do mieszkania' },
-  { label: 'Large', promptText: 'Kuchnia duża do domu' },
-  { label: 'XL', promptText: 'Bardzo duża kuchnia najczęściej z wyspą do domu' },
-];
-
-const FEATURE_CATEGORIES: FeatureCategory[] = [
-  { name: 'Styl kuchni', options: STYLE_FEATURE_OPTIONS },
-  { name: 'Układ kuchni', options: LAYOUT_FEATURE_OPTIONS },
-  { name: 'AGD', options: APPLIANCE_FEATURE_OPTIONS },
-  { name: 'Rozmiar', options: SIZE_FEATURE_OPTIONS },
-];
-
-const FEATURE_OPTIONS: FeatureOption[] = [
-  ...STYLE_FEATURE_OPTIONS,
-  ...LAYOUT_FEATURE_OPTIONS,
-  ...APPLIANCE_FEATURE_OPTIONS,
-  ...SIZE_FEATURE_OPTIONS,
-];
-
-const optionPromptByLabel = (label: string) =>
-  FEATURE_OPTIONS.find((opt) => opt.label === label)?.promptText;
-
-const isOptionPromptText = (text: string) =>
-  FEATURE_OPTIONS.some((opt) => opt.promptText === text);
-
-const extractOptionLabelsFromPrompt = (value: string) => {
-  const parts = value.split(',').map((p) => p.trim()).filter(Boolean);
-  return FEATURE_OPTIONS.filter((opt) => parts.includes(opt.promptText)).map((opt) => opt.label);
-};
-
-const mergePromptWithSelectedOptions = (currentPrompt: string, selectedLabels: string[]) => {
-  const parts = currentPrompt.split(',').map((p) => p.trim()).filter(Boolean);
-  const baseParts = parts.filter((part) => !isOptionPromptText(part));
-  const optionParts = selectedLabels
-    .map((label) => optionPromptByLabel(label))
-    .filter((part): part is string => Boolean(part));
-  return [...baseParts, ...optionParts].join(', ');
-};
-
 function uuidish() {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
@@ -144,7 +49,7 @@ export default function Home() {
     setPrompt((prev) => {
       const merged = mergePromptWithSelectedOptions(prev, selected);
       if (typeof window !== 'undefined') {
-        sessionStorage.setItem('promptDraft', merged);
+        sessionStorage.setItem(PROMPT_STORAGE_KEY, merged);
       }
       return merged;
     });
@@ -227,7 +132,7 @@ export default function Home() {
   // Przywróć wersję roboczą opisu kuchni po powrocie na stronę
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      const savedPrompt = sessionStorage.getItem('promptDraft');
+      const savedPrompt = sessionStorage.getItem(PROMPT_STORAGE_KEY);
       if (savedPrompt) {
         setPrompt(savedPrompt);
         syncOptionsFromPrompt(savedPrompt);
@@ -257,7 +162,7 @@ export default function Home() {
     navigator.clipboard.writeText(text);
     setPrompt(text);
     if (typeof window !== 'undefined') {
-      sessionStorage.setItem('promptDraft', text);
+      sessionStorage.setItem(PROMPT_STORAGE_KEY, text);
     }
     syncOptionsFromPrompt(text);
     autoResize();
@@ -298,7 +203,8 @@ export default function Home() {
   const clamp = (v: number, min: number, max: number) => Math.min(Math.max(v, min), max);
 
   useEffect(() => {
-    const saved = typeof window !== 'undefined' ? localStorage.getItem('aspectRatio') : null;
+    const saved =
+      typeof window !== 'undefined' ? localStorage.getItem(ASPECT_RATIO_STORAGE_KEY) : null;
     if (saved) setAspectRatio(saved);
   }, []);
 
@@ -453,7 +359,7 @@ export default function Home() {
   const selectAspect = (ratio: string) => {
     setAspectRatio(ratio);
     if (typeof window !== 'undefined') {
-      localStorage.setItem('aspectRatio', ratio);
+      localStorage.setItem(ASPECT_RATIO_STORAGE_KEY, ratio);
     }
   };
 
@@ -588,7 +494,7 @@ export default function Home() {
     setPrompt('');
     setOptions([]);
     if (typeof window !== 'undefined') {
-      sessionStorage.removeItem('promptDraft');
+      sessionStorage.removeItem(PROMPT_STORAGE_KEY);
     }
     if (focusTextarea) {
       textareaRef.current?.focus();
@@ -729,7 +635,7 @@ export default function Home() {
     setPrompt('');
     setOptions([]);
     if (typeof window !== 'undefined') {
-      sessionStorage.removeItem('promptDraft');
+      sessionStorage.removeItem(PROMPT_STORAGE_KEY);
     }
     textareaRef.current?.blur();
   };
@@ -797,7 +703,7 @@ export default function Home() {
                   const value = e.target.value;
                   setPrompt(value);
                   if (typeof window !== 'undefined') {
-                    sessionStorage.setItem('promptDraft', value);
+                    sessionStorage.setItem(PROMPT_STORAGE_KEY, value);
                   }
                   autoResize();
                   syncOptionsFromPrompt(value);

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -20,8 +20,17 @@ export default function BottomNav() {
             className="absolute bottom-16 left-0 right-0 bg-white shadow"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="p-4">
-              <AuthButtons />
+            <div className="space-y-4 p-4">
+              <Link
+                href="/moja-kuchnia"
+                onClick={() => setMenuOpen(false)}
+                className="block rounded-xl bg-[#f2f2f2] px-4 py-3 text-base font-medium text-gray-800 transition hover:bg-[#e5e5e5]"
+              >
+                Moja kuchnia
+              </Link>
+              <div className="border-t border-gray-100 pt-4">
+                <AuthButtons />
+              </div>
             </div>
           </div>
         </div>

--- a/src/lib/kitchenFeatures.ts
+++ b/src/lib/kitchenFeatures.ts
@@ -1,0 +1,118 @@
+export type FeatureOption = {
+  label: string;
+  promptText: string;
+};
+
+export type FeatureCategory = {
+  name: string;
+  options: FeatureOption[];
+};
+
+export const PROMPT_STORAGE_KEY = 'promptDraft';
+export const ASPECT_RATIO_STORAGE_KEY = 'aspectRatio';
+
+export const STYLE_FEATURE_OPTIONS: FeatureOption[] = [
+  { label: 'Nowoczesna', promptText: 'Kuchnia nowoczesna' },
+  { label: 'Klasyczna', promptText: 'Kuchnia klasyczna' },
+  { label: 'Skandynawska', promptText: 'Kuchnia w stylu skandynawskim' },
+  { label: 'Loft / Industrial', promptText: 'Kuchnia w stylu loft / industrialnym' },
+  { label: 'Rustykalna', promptText: 'Kuchnia rustykalna' },
+  { label: 'Minimalistyczna', promptText: 'Kuchnia minimalistyczna' },
+  { label: 'Glamour', promptText: 'Kuchnia w stylu glamour' },
+  { label: 'Retro', promptText: 'Kuchnia retro' },
+  { label: 'Boho', promptText: 'Kuchnia boho' },
+  { label: 'Japandi', promptText: 'Kuchnia w stylu japandi' },
+];
+
+export const LAYOUT_FEATURE_OPTIONS: FeatureOption[] = [
+  { label: 'I', promptText: 'Kuchnia na jednej ścianie' },
+  { label: 'L', promptText: 'Kuchnia w literę L' },
+  { label: 'U', promptText: 'Kuchnia w literę U' },
+  {
+    label: 'I I',
+    promptText:
+      'Kuchnia na dwóch równoległych ścianach nie połączonych ze sobą meblami',
+  },
+  { label: 'Wyspa', promptText: 'Kuchnia z wyspą' },
+  {
+    label: 'Barek',
+    promptText:
+      'Kuchnia z podwyższonym wąski blatem jako barkiem pod hokery dostawiona do blatu roboczego',
+  },
+];
+
+export const APPLIANCE_FEATURE_OPTIONS: FeatureOption[] = [
+  {
+    label: 'Lod zab.',
+    promptText:
+      'Kuchnia z jedną lodówką w zabudowie dwoje drzwi na dole front do wysokości blatu drugi front jak pasuje',
+  },
+  { label: 'Lod. woln.', promptText: 'Kuchnia z lodówką pojedynczą szerokości 60cm wysoką' },
+  { label: 'Lod. side', promptText: 'Kuchnia z lodówką side by side dwoje drzwi szeroka' },
+  {
+    label: 'Piek pod pł.',
+    promptText:
+      'Kuchnia z piekarnikiem pod płytą grzewczą 60cm nad okap wolnowiszący lub w zabudowie',
+  },
+  {
+    label: 'Piek w słup.',
+    promptText:
+      'Kuchnia z piekarnikiem w słupku zazwyczaj razem z mikrofalą też w zabudowie',
+  },
+  {
+    label: 'Zlew okno',
+    promptText:
+      'Kuchnia ze zlewozmywakiem pod oknem najczęściej półtorakomory z małym ociekaczem w kuchni tylko jeden zlew',
+  },
+];
+
+export const SIZE_FEATURE_OPTIONS: FeatureOption[] = [
+  { label: 'XS', promptText: 'Mała kuchnia ciasna w bloku' },
+  { label: 'S', promptText: 'Niezaduża kuchnia w mieszkaniu' },
+  { label: 'Medium', promptText: 'Średnia kuchnia do mieszkania' },
+  { label: 'Large', promptText: 'Kuchnia duża do domu' },
+  { label: 'XL', promptText: 'Bardzo duża kuchnia najczęściej z wyspą do domu' },
+];
+
+export const FEATURE_CATEGORIES: FeatureCategory[] = [
+  { name: 'Styl kuchni', options: STYLE_FEATURE_OPTIONS },
+  { name: 'Układ kuchni', options: LAYOUT_FEATURE_OPTIONS },
+  { name: 'AGD', options: APPLIANCE_FEATURE_OPTIONS },
+  { name: 'Rozmiar', options: SIZE_FEATURE_OPTIONS },
+];
+
+export const FEATURE_OPTIONS: FeatureOption[] = [
+  ...STYLE_FEATURE_OPTIONS,
+  ...LAYOUT_FEATURE_OPTIONS,
+  ...APPLIANCE_FEATURE_OPTIONS,
+  ...SIZE_FEATURE_OPTIONS,
+];
+
+export const optionPromptByLabel = (label: string) =>
+  FEATURE_OPTIONS.find((opt) => opt.label === label)?.promptText;
+
+export const isOptionPromptText = (text: string) =>
+  FEATURE_OPTIONS.some((opt) => opt.promptText === text);
+
+export const extractOptionLabelsFromPrompt = (value: string) => {
+  const parts = value
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean);
+  return FEATURE_OPTIONS.filter((opt) => parts.includes(opt.promptText)).map((opt) => opt.label);
+};
+
+export const mergePromptWithSelectedOptions = (
+  currentPrompt: string,
+  selectedLabels: string[],
+) => {
+  const parts = currentPrompt
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const baseParts = parts.filter((part) => !isOptionPromptText(part));
+  const optionParts = selectedLabels
+    .map((label) => optionPromptByLabel(label))
+    .filter((part): part is string => Boolean(part));
+  return [...baseParts, ...optionParts].join(', ');
+};


### PR DESCRIPTION
## Summary
- extract the kitchen feature definitions and related helpers into a shared module
- add a dedicated "Moja kuchnia" page that renders the prompt editor menu permanently and previews the saved description
- surface the new page from the bottom menu while keeping authentication controls available

## Testing
- npm run lint *(fails: ESLint patch error from @rushstack/eslint-patch in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ce94b0d90883298da375cc6a8effee