### PR TITLE
Style prompt settings menu like main menu

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -879,7 +879,7 @@ export default function Home() {
 
       {/* Overlay */}
       <div
-        className={`fixed inset-0 bg-black/30 z-40 transition-opacity duration-300 ${
+        className={`fixed inset-0 z-40 bg-black/40 backdrop-blur-sm transition-opacity duration-300 ${
           menuOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
         }`}
         onClick={() => setMenuOpen(false)}
@@ -887,7 +887,7 @@ export default function Home() {
 
       {/* Sliding menu */}
       <div
-        className={`fixed bottom-16 left-0 right-0 z-50 p-4 bg-white rounded-t-2xl shadow-lg max-h-[75%] overflow-y-auto transform transition-transform duration-300 ${
+        className={`fixed bottom-20 left-4 right-4 z-50 mx-auto max-w-lg rounded-3xl bg-white/95 p-4 shadow-xl ring-1 ring-slate-100 max-h-[75%] overflow-y-auto transform transition-transform duration-300 ${
           menuOpen ? 'translate-y-0' : 'translate-y-full'
         } pb-20`}
       >


### PR DESCRIPTION
## Summary
- align the prompt settings overlay backdrop with the main navigation by applying the blurred black overlay
- restyle the prompt settings container with rounded corners, translucent background, and ring to mirror the main menu frame while keeping the inner content intact

## Testing
- npm run lint *(fails with existing warnings about unused disable and missing dependencies in useEffect)*

------
https://chatgpt.com/codex/tasks/task_b_68cede56799483299322e7f6229482d0