### PR TITLE
Fix hidden prompt settings menu position

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -886,9 +886,14 @@ export default function Home() {
 
       {/* Sliding menu */}
       <div
-        className={`fixed bottom-20 left-4 right-4 z-50 mx-auto max-w-lg rounded-3xl bg-white/95 p-4 shadow-xl ring-1 ring-slate-100 max-h-[75%] overflow-y-auto transform transition-transform duration-300 ${
-          menuOpen ? 'translate-y-0' : 'translate-y-full'
-        } pb-20`}
+        className={`fixed bottom-20 left-4 right-4 z-50 mx-auto max-w-lg rounded-3xl bg-white/95 p-4 shadow-xl ring-1 ring-slate-100 max-h-[75%] overflow-y-auto transition-transform duration-300 pb-20 ${
+          menuOpen ? 'pointer-events-auto' : 'pointer-events-none'
+        }`}
+        style={{
+          transform: menuOpen
+            ? 'translateY(0)'
+            : 'translateY(calc(100% + 6rem + env(safe-area-inset-bottom, 0px)))',
+        }}
       >
         <button
           className="absolute top-3 right-3 flex h-12 w-12 items-center justify-center rounded-full bg-[#f2f2f2] text-3xl leading-none text-gray-600 shadow-sm"


### PR DESCRIPTION
## Summary
- extend the hidden transform offset for the prompt settings panel so it stays below the prompt input
- disable pointer events on the panel while hidden to avoid stray interactions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cee0af22308329bc7c6e8637bb25da