### PR TITLE
Add loader message for pending kitchen generation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -761,9 +761,18 @@ export default function Home() {
                 style={{ aspectRatio: pendingFrame.aspectRatio.replace(':', ' / ') }}
               >
                 <div className="flex h-full w-full items-center justify-center p-4 text-center">
-                  <p className="w-full max-h-full overflow-y-auto whitespace-pre-wrap break-words text-sm text-gray-600">
-                    {pendingFrame.prompt}
-                  </p>
+                  <div className="flex w-full max-w-sm flex-col items-center gap-4">
+                    <span
+                      className="h-12 w-12 animate-spin rounded-full border-4 border-orange-400 border-t-transparent"
+                      aria-hidden="true"
+                    />
+                    <p className="text-base font-medium text-gray-700">
+                      Kuchnia jest w trakcie generowania…
+                    </p>
+                    <p className="w-full max-h-48 overflow-y-auto whitespace-pre-wrap break-words text-sm text-gray-500">
+                      {pendingFrame.prompt}
+                    </p>
+                  </div>
                 </div>
               </div>
             </figure>


### PR DESCRIPTION
## Summary
- show an animated spinner and status text while a kitchen image is being generated
- keep the prompt visible below the new message with improved layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cf19ecf1d08329a30c8649643f7cae