### PR TITLE
Increase sketch pad height

### DIFF
--- a/src/components/RoomSketchPad.tsx
+++ b/src/components/RoomSketchPad.tsx
@@ -844,7 +844,7 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
     [],
   );
   const canvasContainerClassName =
-    'relative w-full overflow-hidden bg-white transition-[border-radius] rounded-2xl border border-slate-200 shadow-sm min-h-[280px] max-h-[min(100vh,640px)] sm:min-h-[320px] sm:max-h-none';
+    'relative w-full overflow-hidden bg-white transition-[border-radius] rounded-2xl border border-slate-200 shadow-sm min-h-[350px] max-h-[min(100vh,800px)] sm:min-h-[400px] sm:max-h-none';
 
   const handleResetViewport = useCallback(() => {
     updateViewport(() => ({ scale: 1, offsetX: 0, offsetY: 0 }));


### PR DESCRIPTION
## Summary
- increase the RoomSketchPad drawing container min-height and max-height by 25% for more vertical space

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cfb7d4e6ec8329b722b3d7542fc7f3