### PR TITLE
Increase mobile sketchpad height

### DIFF
--- a/src/components/RoomSketchPad.tsx
+++ b/src/components/RoomSketchPad.tsx
@@ -844,7 +844,7 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
     [],
   );
   const canvasContainerClassName =
-    'relative w-full overflow-hidden bg-white transition-[border-radius] rounded-2xl border border-slate-200 shadow-sm min-h-[350px] max-h-[min(100vh,800px)] sm:min-h-[400px] sm:max-h-none';
+    'relative w-full overflow-hidden bg-white transition-[border-radius] rounded-2xl border border-slate-200 shadow-sm min-h-[calc(350px*1.25)] max-h-[min(125vh,1000px)] sm:min-h-[400px] sm:max-h-none';
 
   const handleResetViewport = useCallback(() => {
     updateViewport(() => ({ scale: 1, offsetX: 0, offsetY: 0 }));


### PR DESCRIPTION
## Summary
- increase the mobile canvas container min-height by 25% so the drawing grid is taller on phones
- relax the max-height on small screens to give extra space before clamping

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cfbdb087208329a9345b3749edef5a