### PR TITLE
Add scroll strip next to room sketch pad

### DIFF
--- a/src/components/RoomSketchPad.tsx
+++ b/src/components/RoomSketchPad.tsx
@@ -1545,6 +1545,10 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
           onPointerUp={handlePointerUp}
           onPointerCancel={handlePointerCancel}
         />
+        <div
+          aria-hidden
+          className="pointer-events-auto absolute right-0 top-0 h-full w-5 border-l border-slate-200/70 touch-pan-y bg-gradient-to-l from-white via-white/70 to-transparent sm:w-6"
+        />
       </div>
 
       {dimensionOperations.length > 0 && (


### PR DESCRIPTION
## Summary
- add a slim scroll area to the right edge of the room sketch pad canvas so the page can be scrolled while drawing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cfe342df5083298e104c2b8f3df16b