### PR TITLE
Update delete selection control to trash icon

### DIFF
--- a/src/components/RoomSketchPad.tsx
+++ b/src/components/RoomSketchPad.tsx
@@ -1759,9 +1759,12 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
             <button
               type="button"
               onClick={handleDeleteSelected}
-              className="rounded-full border border-rose-200 px-3 py-1.5 text-sm font-medium text-rose-600 transition hover:border-rose-300 hover:bg-rose-50"
+              aria-label="Usuń zaznaczenie"
+              title="Usuń zaznaczenie"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-rose-200 bg-white text-xl text-rose-600 transition hover:border-rose-300 hover:bg-rose-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500"
             >
-              Usuń zaznaczenie
+              <span aria-hidden>🗑️</span>
+              <span className="sr-only">Usuń zaznaczenie</span>
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- restyle the delete-selection control to use the trash icon shown in the top toolbar
- provide aria and title attributes so the icon button remains accessible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cff514018483298d7a2fdb26dc9ed8