### PR TITLE
Remove redo option from room sketch toolbar

### DIFF
--- a/src/components/RoomSketchPad.tsx
+++ b/src/components/RoomSketchPad.tsx
@@ -796,7 +796,6 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
   const [isPanningActive, setIsPanningActive] = useState(false);
   const [selectedOperationId, setSelectedOperationId] = useState<string | null>(null);
   const [detailPickerForOperationId, setDetailPickerForOperationId] = useState<string | null>(null);
-  const [redoCount, setRedoCount] = useState(0);
   const viewportRef = useRef<ViewportState>(viewport);
 
   const applyOperations = useCallback(
@@ -808,7 +807,6 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
       if (!options.preserveRedo) {
         if (redoStackRef.current.length > 0) {
           redoStackRef.current = [];
-          setRedoCount(0);
         }
       }
       const canvas = canvasRef.current;
@@ -828,7 +826,7 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
       }
       onChange({ operations: nextOperations });
     },
-    [onChange, setRedoCount],
+    [onChange],
   );
 
   const updateViewport = useCallback((updater: (previous: ViewportState) => ViewportState) => {
@@ -1024,7 +1022,6 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
     if (lastAppliedOperationsRef.current !== value.operations) {
       if (redoStackRef.current.length > 0) {
         redoStackRef.current = [];
-        setRedoCount(0);
       }
     }
     lastAppliedOperationsRef.current = value.operations;
@@ -1489,22 +1486,8 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
 
     const operationToUndo = operationsRef.current[operationsRef.current.length - 1]!;
     redoStackRef.current = [...redoStackRef.current, operationToUndo];
-    setRedoCount(redoStackRef.current.length);
 
     applyOperations((operations) => operations.slice(0, -1), { preserveRedo: true });
-  }, [applyOperations]);
-
-  const handleRedo = useCallback(() => {
-    if (redoStackRef.current.length === 0) {
-      return;
-    }
-
-    const operationToRestore = redoStackRef.current[redoStackRef.current.length - 1]!;
-    const nextRedoStack = redoStackRef.current.slice(0, -1);
-    redoStackRef.current = nextRedoStack;
-    setRedoCount(nextRedoStack.length);
-
-    applyOperations((operations) => [...operations, operationToRestore], { preserveRedo: true });
   }, [applyOperations]);
 
   const handleClear = useCallback(() => {
@@ -1527,7 +1510,6 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
   }, [applyOperations, selectedOperationId]);
 
   const canUndo = value.operations.length > 0;
-  const canRedo = redoCount > 0;
   const canClear = value.operations.length > 0;
   const canDeleteSelected = Boolean(selectedOperationId);
 
@@ -1594,17 +1576,6 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
             >
               <span aria-hidden>↩️</span>
               <span className="sr-only">Cofnij</span>
-            </button>
-            <button
-              type="button"
-              onClick={handleRedo}
-              disabled={!canRedo}
-              aria-label="Przywróć cofnięty krok"
-              title="Przywróć cofnięty krok"
-              className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:border-sky-200 hover:bg-sky-50 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <span aria-hidden>↪️</span>
-              <span className="sr-only">Przywróć</span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove redo state tracking and callback from the room sketch pad component
- delete the redo button so only the undo control is shown in the toolbar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d03c800890832997f092d6e4104579