### PR TITLE
Add interactive map with company cards

### DIFF
--- a/src/app/firmy/page.tsx
+++ b/src/app/firmy/page.tsx
@@ -1,7 +1,13 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { useMemo, useState } from 'react';
+
 import { companies, cityFilters, serviceFilters } from '@/lib/companies';
+
+const CompanyMap = dynamic(() => import('@/components/CompanyMap'), {
+  ssr: false,
+});
 
 const ratingOptions = [
   { label: 'Dowolna ocena', value: 0 },
@@ -90,18 +96,23 @@ export default function CompaniesPage() {
 
   return (
     <main className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
-      <header className="mx-auto mb-10 max-w-3xl text-center sm:mb-14">
-        <span className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600">
-          Katalog firm
-        </span>
-        <h1 className="mt-4 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
-          Znajdź partnera do stworzenia kuchni marzeń
-        </h1>
-        <p className="mt-4 text-base text-slate-600 sm:text-lg">
-          Zebraliśmy 100 pracowni kuchennych z dziesięciu największych miast w Polsce. Skorzystaj z filtrów,
-          aby szybko zawęzić listę do firm, które najlepiej odpowiadają Twoim potrzebom projektowym i montażowym.
-        </p>
-      </header>
+      <section className="mb-12 grid gap-8 lg:grid-cols-[minmax(0,0.55fr)_minmax(0,1fr)] lg:items-center">
+        <div className="order-1 overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm lg:order-2">
+          <CompanyMap companies={sortedCompanies} />
+        </div>
+        <header className="order-2 mx-auto max-w-3xl text-center lg:order-1 lg:mx-0 lg:text-left">
+          <span className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium uppercase tracking-wide text-slate-600">
+            Katalog firm
+          </span>
+          <h1 className="mt-4 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+            Znajdź partnera do stworzenia kuchni marzeń
+          </h1>
+          <p className="mt-4 text-base text-slate-600 sm:text-lg">
+            Zebraliśmy 100 pracowni kuchennych z dziesięciu największych miast w Polsce. Wykorzystaj interaktywną mapę oraz
+            filtry, aby szybko zawęzić listę do firm, które najlepiej odpowiadają Twoim potrzebom projektowym i montażowym.
+          </p>
+        </header>
+      </section>
 
       <section className="mb-12 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
         <div className="grid gap-4 md:grid-cols-3">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,3 +40,16 @@ body {
   opacity: 0;
   animation: placeholderFadeIn 0.6s ease forwards;
 }
+
+.company-popup .leaflet-popup-content {
+  margin: 0;
+}
+
+.company-popup .leaflet-popup-content-wrapper {
+  border-radius: 1.5rem;
+  padding: 0;
+}
+
+.company-popup .leaflet-popup-tip {
+  background: #ffffff;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import "./globals.css";
+import "leaflet/dist/leaflet.css";
 import BottomNav from "@/components/BottomNav";
 import ScrollToTop from "@/components/ScrollToTop";
 

--- a/src/components/CompanyMap.tsx
+++ b/src/components/CompanyMap.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet';
+import L, { Map as LeafletMap } from 'leaflet';
+
+import type { Company } from '@/lib/companies';
+import { cityCoordinates } from '@/lib/city-coordinates';
+
+import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+
+type CompanyMapProps = {
+  companies: Company[];
+};
+
+type CityMarker = {
+  city: string;
+  voivodeship: string;
+  position: [number, number];
+  companies: Company[];
+};
+
+const defaultCenter: [number, number] = [52.1, 19.4];
+const defaultZoom = 6;
+
+const formatCompanyCount = (count: number) => {
+  if (count === 1) {
+    return '1 firmę';
+  }
+  if ([2, 3, 4].includes(count % 10) && ![12, 13, 14].includes(count % 100)) {
+    return `${count} firmy`;
+  }
+  return `${count} firm`;
+};
+
+const formatCityCount = (count: number) => {
+  if (count === 1) {
+    return '1 mieście';
+  }
+  return `${count} miastach`;
+};
+
+const servicesPreview = (services: string[]) => {
+  if (services.length <= 3) {
+    return services;
+  }
+
+  return [...services.slice(0, 3), `+${services.length - 3}`];
+};
+
+export default function CompanyMap({ companies }: CompanyMapProps) {
+  const [isClient, setIsClient] = useState(false);
+  const mapRef = useRef<LeafletMap | null>(null);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isClient) {
+      return;
+    }
+
+    L.Icon.Default.mergeOptions({
+      iconRetinaUrl: markerIcon2x,
+      iconUrl: markerIcon,
+      shadowUrl: markerShadow,
+    });
+  }, [isClient]);
+
+  const markers = useMemo<CityMarker[]>(() => {
+    const grouped = new Map<string, Company[]>();
+
+    companies.forEach((company) => {
+      if (!cityCoordinates[company.city]) {
+        return;
+      }
+
+      if (!grouped.has(company.city)) {
+        grouped.set(company.city, []);
+      }
+
+      grouped.get(company.city)!.push(company);
+    });
+
+    return Array.from(grouped.entries())
+      .map(([city, cityCompanies]) => {
+        const coordinates = cityCoordinates[city];
+        return {
+          city,
+          voivodeship: cityCompanies[0]?.voivodeship ?? '',
+          position: [coordinates.lat, coordinates.lng] as [number, number],
+          companies: [...cityCompanies].sort((a, b) => {
+            if (b.rating !== a.rating) {
+              return b.rating - a.rating;
+            }
+            return a.name.localeCompare(b.name);
+          }),
+        } satisfies CityMarker;
+      })
+      .sort((first, second) => first.city.localeCompare(second.city));
+  }, [companies]);
+
+  useEffect(() => {
+    if (!isClient || !mapRef.current) {
+      return;
+    }
+
+    if (markers.length === 0) {
+      mapRef.current.setView(defaultCenter, defaultZoom);
+      return;
+    }
+
+    if (markers.length === 1) {
+      mapRef.current.setView(markers[0].position, 11);
+      return;
+    }
+
+    const bounds = L.latLngBounds(markers.map((marker) => marker.position));
+    mapRef.current.fitBounds(bounds, { padding: [40, 40] });
+  }, [markers, isClient]);
+
+  return (
+    <div className="relative h-[420px] w-full">
+      {isClient ? (
+        <MapContainer
+          center={defaultCenter}
+          zoom={defaultZoom}
+          className="h-full w-full"
+          scrollWheelZoom={false}
+          preferCanvas={false}
+          whenCreated={(mapInstance) => {
+            mapRef.current = mapInstance;
+          }}
+        >
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            maxZoom={18}
+          />
+          {markers.map((marker) => (
+            <Marker key={marker.city} position={marker.position}>
+              <Popup className="company-popup" maxWidth={360} minWidth={260}>
+                <div className="flex min-w-[240px] max-w-[320px] flex-col gap-4 p-4">
+                  <header className="space-y-1">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.25em] text-slate-500">
+                      {marker.city} · woj. {marker.voivodeship}
+                    </p>
+                    <h3 className="text-base font-semibold text-slate-900">
+                      Najlepiej oceniane studia kuchenne
+                    </h3>
+                    <p className="text-xs text-slate-600">
+                      {formatCompanyCount(marker.companies.length)} dostępne w tym mieście.
+                    </p>
+                  </header>
+
+                  <div className="max-h-56 space-y-3 overflow-y-auto pr-1">
+                    {marker.companies.map((company) => (
+                      <article
+                        key={company.id}
+                        className="rounded-2xl border border-slate-200 bg-white/95 p-3 shadow-sm transition hover:border-slate-300"
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <h4 className="text-sm font-semibold text-slate-900">{company.name}</h4>
+                          <span className="inline-flex shrink-0 items-center rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700">
+                            {company.rating.toFixed(1)}
+                          </span>
+                        </div>
+                        <p className="mt-2 text-xs leading-relaxed text-slate-600">{company.description}</p>
+                        <div className="mt-3 flex flex-wrap gap-1.5">
+                          {servicesPreview(company.services).map((service) => (
+                            <span
+                              key={service}
+                              className="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-700"
+                            >
+                              {service}
+                            </span>
+                          ))}
+                        </div>
+                        <a
+                          href={company.website}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-3 inline-flex items-center gap-1 text-xs font-semibold text-slate-900 hover:text-slate-600"
+                        >
+                          Odwiedź stronę
+                          <span aria-hidden>→</span>
+                        </a>
+                      </article>
+                    ))}
+                  </div>
+                </div>
+              </Popup>
+            </Marker>
+          ))}
+        </MapContainer>
+      ) : (
+        <div className="flex h-full items-center justify-center bg-slate-50 text-sm text-slate-500">
+          Ładujemy mapę firm...
+        </div>
+      )}
+
+      <div className="pointer-events-none absolute left-4 top-4 flex max-w-xs flex-col gap-1 rounded-2xl bg-white/95 p-4 text-slate-600 shadow-lg backdrop-blur">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.35em] text-slate-500">Wyniki na mapie</p>
+        {companies.length > 0 && markers.length > 0 ? (
+          <>
+            <p className="text-sm font-semibold text-slate-900">{formatCompanyCount(companies.length)}</p>
+            <p className="text-xs">Partnerzy w {formatCityCount(markers.length)}.</p>
+          </>
+        ) : (
+          <p className="text-xs">Brak firm spełniających wybrane kryteria.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/city-coordinates.ts
+++ b/src/lib/city-coordinates.ts
@@ -1,0 +1,17 @@
+export type CityCoordinates = {
+  lat: number;
+  lng: number;
+};
+
+export const cityCoordinates = {
+  Bydgoszcz: { lat: 53.1235, lng: 18.0084 },
+  'Gdańsk': { lat: 54.352, lng: 18.6466 },
+  Katowice: { lat: 50.2649, lng: 19.0238 },
+  'Kraków': { lat: 50.0647, lng: 19.945 },
+  Lublin: { lat: 51.2465, lng: 22.5684 },
+  'Poznań': { lat: 52.4064, lng: 16.9252 },
+  Szczecin: { lat: 53.4285, lng: 14.5528 },
+  'Warszawa': { lat: 52.2297, lng: 21.0122 },
+  'Wrocław': { lat: 51.1079, lng: 17.0385 },
+  'Łódź': { lat: 51.7592, lng: 19.455 },
+} satisfies Record<string, CityCoordinates>;

--- a/types/images.d.ts
+++ b/types/images.d.ts
@@ -1,0 +1,19 @@
+declare module '*.png' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.jpg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.jpeg' {
+  const value: string;
+  export default value;
+}
+
+declare module '*.svg' {
+  const value: string;
+  export default value;
+}


### PR DESCRIPTION
## Summary
- add a Leaflet-powered map with grouped company cards to the firms catalog hero section
- provide shared city coordinates, Leaflet assets, and popup styling for the new map experience
- declare static asset modules to satisfy TypeScript when importing Leaflet icons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d03ebce6f48329b0e71759fb33a3cb