### PR TITLE
Show individual company pins on map

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,3 +40,12 @@ body {
   opacity: 0;
   animation: placeholderFadeIn 0.6s ease forwards;
 }
+
+.company-map-pin {
+  background: transparent;
+  border: none;
+}
+
+.company-map-pin svg {
+  display: block;
+}

--- a/src/components/CompanyMap.tsx
+++ b/src/components/CompanyMap.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useEffect, useMemo } from 'react';
-import type { LatLngTuple } from 'leaflet';
-import { CircleMarker, MapContainer, Popup, TileLayer, Tooltip, useMap } from 'react-leaflet';
+import { DivIcon, type LatLngTuple } from 'leaflet';
+import { MapContainer, Marker, Popup, TileLayer, Tooltip, useMap } from 'react-leaflet';
 
 import type { Company } from '@/lib/companies';
 
@@ -22,18 +22,54 @@ const cityCoordinates: Record<string, { lat: number; lng: number }> = {
 const DEFAULT_CENTER: LatLngTuple = [52.237049, 19.015164];
 const DEFAULT_ZOOM = 6;
 const FOCUS_ZOOM = 11;
+const GOLDEN_ANGLE = 137.508;
+const PIN_SIZE: [number, number] = [32, 40];
+
+const createPinIcon = (variant: 'default' | 'active' | 'dimmed') => {
+  const fill = variant === 'active' ? '#0f172a' : '#f97316';
+  const innerFill = variant === 'active' ? '#e2e8f0' : '#ffffff';
+  const opacity = variant === 'dimmed' ? 0.55 : 1;
+
+  const html = `
+    <svg width="${PIN_SIZE[0]}" height="${PIN_SIZE[1]}" viewBox="0 0 32 40" xmlns="http://www.w3.org/2000/svg" style="display:block;filter:drop-shadow(0 6px 12px rgba(15,23,42,0.35));opacity:${opacity};">
+      <path d="M16 0C9.37258 0 4 5.37258 4 12C4 21 16 40 16 40C16 40 28 21 28 12C28 5.37258 22.6274 0 16 0Z" fill="${fill}" />
+      <circle cx="16" cy="12" r="6" fill="${innerFill}" />
+    </svg>
+  `;
+
+  return new DivIcon({
+    className: 'company-map-pin leaflet-div-icon',
+    html,
+    iconSize: PIN_SIZE,
+    iconAnchor: [PIN_SIZE[0] / 2, PIN_SIZE[1] - 2],
+    popupAnchor: [0, -PIN_SIZE[1] + 10],
+    tooltipAnchor: [0, -PIN_SIZE[1] + 12],
+  });
+};
+
+const computeCompanyPosition = (
+  base: LatLngTuple,
+  index: number,
+): LatLngTuple => {
+  if (index === 0) {
+    return base;
+  }
+
+  const angle = ((index - 1) * GOLDEN_ANGLE * Math.PI) / 180;
+  const ring = Math.floor((index - 1) / 8);
+  const radius = 0.008 + ring * 0.004;
+  const latitudeOffset = radius * Math.cos(angle);
+  const longitudeOffset =
+    (radius * Math.sin(angle)) /
+    Math.cos((base[0] * Math.PI) / 180);
+
+  return [base[0] + latitudeOffset, base[1] + longitudeOffset];
+};
 
 export type CompanyMapProps = {
   companies: Company[];
   selectedCity?: string;
   onCitySelect?: (city: string) => void;
-};
-
-type CityGroup = {
-  city: string;
-  voivodeship: string;
-  coordinates: LatLngTuple;
-  companies: Company[];
 };
 
 const MapViewUpdater = ({ center, zoom }: { center: LatLngTuple; zoom: number }) => {
@@ -50,8 +86,11 @@ const CompanyMap = ({ companies, selectedCity, onCitySelect }: CompanyMapProps) 
   const normalizedSelectedCity =
     selectedCity && cityCoordinates[selectedCity] ? selectedCity : null;
 
-  const cityGroups = useMemo(() => {
-    const grouped = new Map<string, CityGroup>();
+  const companyMarkers = useMemo(() => {
+    const grouped = new Map<
+      string,
+      { base: LatLngTuple; companies: Company[] }
+    >();
 
     companies.forEach((company) => {
       const coordinates = cityCoordinates[company.city];
@@ -61,9 +100,7 @@ const CompanyMap = ({ companies, selectedCity, onCitySelect }: CompanyMapProps) 
 
       if (!grouped.has(company.city)) {
         grouped.set(company.city, {
-          city: company.city,
-          voivodeship: company.voivodeship,
-          coordinates: [coordinates.lat, coordinates.lng],
+          base: [coordinates.lat, coordinates.lng],
           companies: [],
         });
       }
@@ -71,15 +108,20 @@ const CompanyMap = ({ companies, selectedCity, onCitySelect }: CompanyMapProps) 
       grouped.get(company.city)!.companies.push(company);
     });
 
-    return Array.from(grouped.values()).map((group) => ({
-      ...group,
-      companies: [...group.companies].sort((a, b) => {
+    return Array.from(grouped.entries()).flatMap(([city, group]) => {
+      const sortedCompanies = [...group.companies].sort((a, b) => {
         if (b.rating !== a.rating) {
           return b.rating - a.rating;
         }
         return a.name.localeCompare(b.name);
-      }),
-    }));
+      });
+
+      return sortedCompanies.map((company, index) => ({
+        company,
+        city,
+        coordinates: computeCompanyPosition(group.base, index),
+      }));
+    });
   }, [companies]);
 
   const focusCenter = useMemo<LatLngTuple>(() => {
@@ -93,11 +135,15 @@ const CompanyMap = ({ companies, selectedCity, onCitySelect }: CompanyMapProps) 
 
   const focusZoom = normalizedSelectedCity ? FOCUS_ZOOM : DEFAULT_ZOOM;
 
-  const maxGroupSize = useMemo(() => {
-    return cityGroups.reduce((max, group) => Math.max(max, group.companies.length), 0);
-  }, [cityGroups]);
+  const pinIcons = useMemo(() => ({
+    default: createPinIcon('default'),
+    active: createPinIcon('active'),
+    dimmed: createPinIcon('dimmed'),
+  }), []);
 
-  const visibleCityCount = cityGroups.length;
+  const visibleCityCount = useMemo(() => {
+    return new Set(companyMarkers.map((marker) => marker.city)).size;
+  }, [companyMarkers]);
 
   return (
     <div className="relative h-[420px] w-full">
@@ -115,94 +161,92 @@ const CompanyMap = ({ companies, selectedCity, onCitySelect }: CompanyMapProps) 
         />
         <MapViewUpdater center={focusCenter} zoom={focusZoom} />
 
-        {cityGroups.map((group) => {
-          const isSelected = normalizedSelectedCity === group.city;
-          const scaledRadius = maxGroupSize
-            ? 8 + (group.companies.length / maxGroupSize) * 6
-            : 8;
-          const radius = isSelected ? scaledRadius + 2 : scaledRadius;
+        {companyMarkers.map((marker) => {
+          const isSelectedCity = normalizedSelectedCity === marker.city;
+          const iconVariant = normalizedSelectedCity
+            ? isSelectedCity
+              ? 'active'
+              : 'dimmed'
+            : 'default';
 
           return (
-            <CircleMarker
-              key={group.city}
-              center={group.coordinates}
-              radius={radius}
-              pathOptions={{
-                color: isSelected ? '#0f172a' : '#1e3a8a',
-                fillColor: isSelected ? '#0f172a' : '#2563eb',
-                fillOpacity: 0.8,
-                weight: isSelected ? 3 : 2,
-              }}
+            <Marker
+              key={marker.company.id}
+              position={marker.coordinates}
+              icon={pinIcons[iconVariant]}
               eventHandlers={{
                 click: () => {
-                  onCitySelect?.(group.city);
+                  onCitySelect?.(marker.city);
                 },
               }}
             >
-              <Tooltip direction="top" offset={[0, -12]} opacity={0.95}>
+              <Tooltip direction="top" offset={[0, -32]} opacity={0.95}>
                 <div className="flex flex-col gap-0.5">
-                  <span className="text-sm font-semibold text-slate-900">{group.city}</span>
+                  <span className="text-sm font-semibold text-slate-900">
+                    {marker.company.name}
+                  </span>
                   <span className="text-xs font-medium text-slate-600">
-                    {group.companies.length} firm
+                    {marker.city} · ocena {marker.company.rating.toFixed(1)}
                   </span>
                 </div>
               </Tooltip>
               <Popup>
                 <div className="space-y-3">
-                  <div>
+                  <div className="space-y-1">
                     <p className="text-sm font-semibold text-slate-900">
-                      {group.city} · woj. {group.voivodeship}
+                      {marker.company.name}
                     </p>
                     <p className="text-xs text-slate-600">
-                      {group.companies.length} {group.companies.length === 1 ? 'firma' : 'firmy'} w katalogu
+                      {marker.city} · woj. {marker.company.voivodeship}
                     </p>
+                    <span className="inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-700">
+                      Ocena {marker.company.rating.toFixed(1)}
+                    </span>
                   </div>
-                  <div className="max-h-48 space-y-2 overflow-y-auto pr-1">
-                    {group.companies.map((company) => {
-                      const servicesSummary =
-                        company.services.slice(0, 2).join(' · ') || 'Pełen zakres usług';
-
-                      return (
-                        <div key={company.id} className="space-y-1 rounded-lg border border-slate-200 p-2">
-                          <a
-                            href={company.website}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-sm font-medium text-slate-900 hover:text-slate-700"
-                          >
-                            {company.name}
-                          </a>
-                          <div className="flex items-center justify-between text-xs text-slate-600">
-                            <span>{servicesSummary}</span>
-                            <span className="font-medium text-emerald-700">
-                              {company.rating.toFixed(1)} ★
-                            </span>
-                          </div>
-                        </div>
-                      );
-                    })}
+                  <p className="text-xs leading-relaxed text-slate-600">
+                    {marker.company.description}
+                  </p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {marker.company.services.slice(0, 4).map((service) => (
+                      <span
+                        key={service}
+                        className="inline-flex items-center rounded-full bg-slate-100 px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-slate-700"
+                      >
+                        {service}
+                      </span>
+                    ))}
                   </div>
-                  {onCitySelect ? (
-                    <button
-                      type="button"
-                      onClick={() => onCitySelect(group.city)}
-                      className="w-full rounded-full bg-slate-900 px-3 py-2 text-xs font-semibold text-white transition hover:bg-slate-800"
+                  <div className="flex flex-col gap-2 pt-1">
+                    <a
+                      href={marker.company.website}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center justify-center rounded-full bg-slate-900 px-3 py-2 text-xs font-semibold text-white transition hover:bg-slate-800"
                     >
-                      {normalizedSelectedCity === group.city
-                        ? 'Pokaż wszystkie miasta'
-                        : `Filtruj firmy w mieście ${group.city}`}
-                    </button>
-                  ) : null}
+                      Odwiedź stronę
+                    </a>
+                    {onCitySelect ? (
+                      <button
+                        type="button"
+                        onClick={() => onCitySelect(marker.city)}
+                        className="inline-flex items-center justify-center rounded-full border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+                      >
+                        {normalizedSelectedCity === marker.city
+                          ? 'Pokaż wszystkie miasta'
+                          : `Filtruj firmy w mieście ${marker.city}`}
+                      </button>
+                    ) : null}
+                  </div>
                 </div>
               </Popup>
-            </CircleMarker>
+            </Marker>
           );
         })}
       </MapContainer>
 
       <div className="pointer-events-none absolute left-4 top-4 rounded-full bg-white/90 px-4 py-2 text-xs font-medium text-slate-700 shadow">
-        {visibleCityCount > 0
-          ? `Na mapie: ${visibleCityCount} ${visibleCityCount === 1 ? 'miasto' : 'miasta'} · ${companies.length} firm`
+        {companyMarkers.length > 0
+          ? `Na mapie: ${visibleCityCount} ${visibleCityCount === 1 ? 'miasto' : 'miasta'} · ${companyMarkers.length} firm`
           : 'Brak firm spełniających wybrane kryteria'}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace aggregated city markers with individual company pins that spread around each city and show descriptive popups
- add custom SVG-based map pin icons and highlight behaviour for the selected city
- adjust map overlay counts to reflect visible company markers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d048bee9688329b50fa9faf7279da3