### PR TITLE
Ensure company map renders beneath navigation menus

### DIFF
--- a/src/components/CompanyMap.tsx
+++ b/src/components/CompanyMap.tsx
@@ -146,7 +146,7 @@ const CompanyMap = ({ companies, selectedCity, onCitySelect }: CompanyMapProps) 
   }, [companyMarkers]);
 
   return (
-    <div className="relative h-[420px] w-full">
+    <div className="relative isolate z-0 h-[420px] w-full">
       <MapContainer
         center={DEFAULT_CENTER}
         zoom={DEFAULT_ZOOM}


### PR DESCRIPTION
## Summary
- isolate the company map container so its Leaflet panes remain below the site navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d0564bd4388329a46a6fbdb0046161