### PR TITLE
Make selection handles outline-only

### DIFF
--- a/src/components/RoomSketchPad.tsx
+++ b/src/components/RoomSketchPad.tsx
@@ -394,16 +394,13 @@ function drawOperation(
       ctx.globalAlpha = 1;
       ctx.lineWidth = HANDLE_OUTLINE_WIDTH;
       ctx.strokeStyle = '#0284c7';
-      ctx.fillStyle = '#ffffff';
 
       ctx.beginPath();
       ctx.arc(start.x, start.y, HANDLE_VISUAL_RADIUS_PX, 0, Math.PI * 2);
-      ctx.fill();
       ctx.stroke();
 
       ctx.beginPath();
       ctx.arc(end.x, end.y, HANDLE_VISUAL_RADIUS_PX, 0, Math.PI * 2);
-      ctx.fill();
       ctx.stroke();
       ctx.restore();
     }
@@ -456,16 +453,13 @@ function drawOperation(
       ctx.globalAlpha = 1;
       ctx.lineWidth = HANDLE_OUTLINE_WIDTH;
       ctx.strokeStyle = '#0284c7';
-      ctx.fillStyle = '#ffffff';
 
       ctx.beginPath();
       ctx.arc(start.x, start.y, HANDLE_VISUAL_RADIUS_PX, 0, Math.PI * 2);
-      ctx.fill();
       ctx.stroke();
 
       ctx.beginPath();
       ctx.arc(end.x, end.y, HANDLE_VISUAL_RADIUS_PX, 0, Math.PI * 2);
-      ctx.fill();
       ctx.stroke();
       ctx.restore();
     }


### PR DESCRIPTION
## Summary
- render selection handles for lines and dimensions without white fill to improve precise adjustments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d057f5e4a8832980c0a0a29b0bd294