### PR TITLE
Move drawing module above room features

### DIFF
--- a/src/app/moja-kuchnia/page.tsx
+++ b/src/app/moja-kuchnia/page.tsx
@@ -583,6 +583,8 @@ export default function MyKitchenPage() {
 
         <div className="mt-12 grid gap-8 lg:grid-cols-[2fr,1fr] lg:items-start">
           <div className="space-y-8">
+            <RoomSketchPad value={sketch} onChange={setSketch} />
+
             {CATEGORIES.map((category) => {
               const selectedValues = selections[category.id] ?? [];
               const allValues = category.options.map((option) => option.value);
@@ -698,8 +700,6 @@ export default function MyKitchenPage() {
                 </section>
               );
             })}
-
-            <RoomSketchPad value={sketch} onChange={setSketch} />
 
             <section className="rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-sm backdrop-blur-sm">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">


### PR DESCRIPTION
## Summary
- place the room sketch pad at the top of the customizable kitchen page before the feature selectors so the drawing tool is immediately accessible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d063fc81008329b8a3262108a018fc