### PR TITLE
Adjust wall offset validation highlight behavior

### DIFF
--- a/src/components/RoomSketchPad.tsx
+++ b/src/components/RoomSketchPad.tsx
@@ -2644,8 +2644,10 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
                                             'border border-slate-200 focus:border-sky-300 focus:ring-sky-200';
                                           const invalidBorderClassName =
                                             'border border-rose-400 focus:border-rose-400 focus:ring-rose-200';
+                                          const shouldHighlightWallOffsetDirection =
+                                            isWallOffsetField && fieldValue.trim() !== '' && !wallOffsetDirection;
                                           const inputClassName = `${baseInputClassName} ${
-                                            isWallOffsetField && !wallOffsetDirection
+                                            shouldHighlightWallOffsetDirection
                                               ? invalidBorderClassName
                                               : defaultBorderClassName
                                           }`;
@@ -2686,7 +2688,7 @@ export default function RoomSketchPad({ value, onChange, className }: Props) {
                                                     }
                                                     className={inputClassName}
                                                     placeholder="np. 120"
-                                                    aria-invalid={!wallOffsetDirection}
+                                                    aria-invalid={shouldHighlightWallOffsetDirection}
                                                   />
                                                   <div className="flex items-center gap-1">
                                                     {(['left', 'right'] as const).map((direction) => {


### PR DESCRIPTION
## Summary
- update the wall offset dimension input to highlight as invalid only when a value is provided without selecting L or P
- keep the invalid styling in sync with the aria-invalid attribute for assistive technologies

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d0f5920ec88329a9174329224c752e