### PR TITLE
Rename Explore and Firmy pages to Inspiracje and Oferty

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,7 +1,7 @@
-export default function ExplorePage() {
+export default function InspiracjePage() {
   return (
     <main className="p-6 pb-24">
-      <h1 className="text-2xl font-bold mb-4">Explore</h1>
+      <h1 className="text-2xl font-bold mb-4">Inspiracje</h1>
       <p>Galeria już wkrótce.</p>
     </main>
   );

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -81,7 +81,7 @@ export default function BottomNav() {
                           : 'hover:bg-orange-50 hover:text-orange-600'
                       }`}
                     >
-                      <span>Strefa firm</span>
+                      <span>Strefa ofert</span>
                       <span aria-hidden className="text-lg">→</span>
                     </Link>
                   </li>
@@ -110,7 +110,7 @@ export default function BottomNav() {
               }`}
             >
               <span className="text-xl">🧭</span>
-              Explore
+              Inspiracje
             </Link>
           </li>
           <li>
@@ -132,7 +132,7 @@ export default function BottomNav() {
               }`}
             >
               <span className="text-xl">🏢</span>
-              Firmy
+              Oferty
             </Link>
           </li>
         </ul>


### PR DESCRIPTION
## Summary
- rename the explore page heading to Inspiracje
- update bottom navigation labels and shortcuts to use Inspiracje and Oferty naming

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d34fdeaac08329a973299796c5a185